### PR TITLE
Door pointer fixes, Title screen PPU data padding

### DIFF
--- a/config.asm
+++ b/config.asm
@@ -114,6 +114,9 @@ PRESERVE_UNUSED_SPACE = 1
 ; Based on RetroRain's MMC5 patch (https://www.romhacking.net/hacks/2568)
 ; MMC5 = 1
 
+; Pads title screen PPU data for easier modification
+; PAD_TITLE_SCREEN_PPU_DATA = 1
+
 ; Skip unnecessary bonus chance RAM copy
 ; BONUS_CHANCE_RAM_CLEANUP = 1
 

--- a/src/levels/1/1-1/1-1-area5.asm
+++ b/src/levels/1/1-1/1-1-area5.asm
@@ -26,7 +26,12 @@ LevelData_1_1_Area5:
 	.db $24, $83
 	.db $25, $81
 	.db $4B, $0B
+IFNDEF DISABLE_DOOR_POINTERS
 	.db $00, $30
+ENDIF
+IFDEF DISABLE_DOOR_POINTERS
+	.db $F5, $00, $30
+ENDIF
 	.db $F0, $8B
 	.db $F1, $8C
 	.db $F1, $CA

--- a/src/levels/1/1-2/1-2-area0.asm
+++ b/src/levels/1/1-2/1-2-area0.asm
@@ -50,7 +50,12 @@ ENDIF
 	.db $3C, $16
 	.db $1D, $16
 	.db $13, $0B
+IFNDEF DISABLE_DOOR_POINTERS
 	.db $01, $13
+ENDIF
+IFDEF DISABLE_DOOR_POINTERS
+	.db $F5, $01, $13
+ENDIF
 	.db $15, $56
 	.db $0E, $51
 	.db $9C, $8C
@@ -62,7 +67,12 @@ ENDIF
 	.db $4A, $16
 	.db $14, $16
 	.db $0C, $0B
+IFNDEF DISABLE_DOOR_POINTERS
 	.db $01, $20
+ENDIF
+IFDEF DISABLE_DOOR_POINTERS
+	.db $F5, $01, $20
+ENDIF
 	.db $26, $16
 	.db $09, $82
 	.db $0A, $82

--- a/src/levels/1/1-2/1-2-area1.asm
+++ b/src/levels/1/1-2/1-2-area1.asm
@@ -6,7 +6,12 @@ LevelData_1_2_Area1:
 	.db $16, $29
 	.db $0C, $29
 	.db $12, $13
+IFNDEF DISABLE_DOOR_POINTERS
 	.db $01, $04
+ENDIF
+IFDEF DISABLE_DOOR_POINTERS
+	.db $F5, $01, $04
+ENDIF
 	.db $1A, $25
 	.db $0C, $21
 	.db $0E, $21

--- a/src/prg-0-1.asm
+++ b/src/prg-0-1.asm
@@ -4571,7 +4571,7 @@ ENDIF
 
 TitleScreenPPUDataPointers:
 	.dw PPUBuffer_301
-	.dw TitleLayout1
+	.dw TitleLayout
 
 
 ; =============== S U B R O U T I N E =======================================
@@ -4604,7 +4604,7 @@ WaitForNMI_TitleScreenLoop:
 ; End of function WaitForNMI_TitleScreen
 
 
-TitleLayout1:
+TitleLayout:
 	; red lines, vertical, left
 	.db $20, $00, $DE, $FD
 	.db $20, $01, $DE, $FD
@@ -4670,7 +4670,7 @@ TitleLayout1:
 	.db $23, $89, $02, $AA, $AB
 
 	; SUPER
-	;                    SSSSSSSS  UUUUUUUU  PPPPPPPP  EEEEEEEE  RRRRRRRR
+	;                  SSSSSSSS  UUUUUUUU  PPPPPPPP  EEEEEEEE  RRRRRRRR
 	.db $20, $CB, $0A, $00, $01, $08, $08, $FC, $01, $FC, $08, $FC, $01
 	.db $20, $EB, $0A, $02, $03, $08, $08, $0A, $05, $0B, $0C, $0A, $0D
 	.db $21, $0B, $0A, $04, $05, $04, $05, $0E, $07, $FC, $08, $0E, $08
@@ -4678,11 +4678,11 @@ TitleLayout1:
 	.db $21, $31, $04, $76, $09, $09, $09
 
 	; TM
-	;                    TTT  MMM
+	;                  TTT  MMM
 	.db $21, $38, $02, $F9, $FA
 
 	; MARIO
-	;                    MMMMMMMMMMMMM  AAAAAAAA  RRRRRRRR  III  OOOOOOOO
+	;                  MMMMMMMMMMMMM  AAAAAAAA  RRRRRRRR  III  OOOOOOOO
 	.db $21, $46, $0A, $00, $0F, $01, $00, $01, $FC, $01, $08, $00, $01
 	.db $21, $66, $0A, $10, $10, $08, $10, $08, $10, $08, $08, $10, $08
 	.db $21, $86, $0A, $08, $08, $08, $08, $08, $13, $0D, $08, $08, $08
@@ -4691,7 +4691,7 @@ TitleLayout1:
 	.db $21, $E6, $0A, $09, $09, $09, $09, $09, $09, $09, $09, $06, $07
 
 	; BROS
-	;                    BBBBBBBB  RRRRRRRR  OOOOOOOO  SSSSSSSS
+	;                  BBBBBBBB  RRRRRRRR  OOOOOOOO  SSSSSSSS
 	.db $21, $51, $08, $FC, $01, $FC, $01, $00, $01, $00, $01 ; BROS
 	.db $21, $71, $08, $10, $08, $10, $08, $10, $08, $10, $08
 	.db $21, $91, $08, $13, $0D, $13, $0D, $08, $08, $77, $03
@@ -4700,7 +4700,7 @@ TitleLayout1:
 	.db $21, $F1, $09, $11, $07, $09, $09, $06, $07, $06, $07, $09
 
 	; 2
-	;               22222222222222222222222
+	;             22222222222222222222222
 	.db $22, $0E, $04, $14, $15, $16, $17
 	.db $22, $2E, $04, $18, $19, $1A, $1B
 	.db $22, $4E, $04, $1C, $1D, $1E, $1F
@@ -4708,11 +4708,11 @@ TitleLayout1:
 	.db $22, $8E, $04, $76, $76, $76, $21
 
 	; (C) 1988
-	;                    (C)  111  999  888  888
+	;                  (C)  111  999  888  888
 	.db $22, $E9, $05, $F8, $D1, $D9, $D8, $D8  ; (C) 1988
 
 	; NINTENDO
-	;                    NNN  III  NNN  TTT  EEE  NNN  DDD  OOO
+	;                  NNN  III  NNN  TTT  EEE  NNN  DDD  OOO
 	.db $22, $EF, $08, $E7, $E2, $E7, $ED, $DE, $E7, $DD, $E8
 
 	.db $23, $CA, $04, $80, $A0, $A0, $20
@@ -4720,6 +4720,10 @@ TitleLayout1:
 	.db $23, $E3, $02, $88, $22
 	.db $23, $EA, $04, $F0, $F8, $F2, $F0
 	.db $00
+
+IFDEF PAD_TITLE_SCREEN_PPU_DATA
+	.pad TitleLayout + $300, $00
+ENDIF
 
 TitleBackgroundPalettes:
 	.db $22, $37, $16, $07 ; Most of screen, outline, etc.


### PR DESCRIPTION
* Adds `PAD_TITLE_SCREEN_PPU_DATA`, which ensures that the title screen has `$300` bytes for its PPU data (for modifications without recompiling)
* Fixes a few `DISABLE_DOOR_POINTERS` area pointers that I either forgot or lost while merging earlier