### PR TITLE
Tile annotations, level header macro, and pigit

### DIFF
--- a/config.asm
+++ b/config.asm
@@ -117,6 +117,9 @@ PRESERVE_UNUSED_SPACE = 1
 ; Pads title screen PPU data for easier modification
 ; PAD_TITLE_SCREEN_PPU_DATA = 1
 
+; Expands various lookup tables so that more values can be added
+; EXPAND_TABLES = 1
+
 ; Skip unnecessary bonus chance RAM copy
 ; BONUS_CHANCE_RAM_CLEANUP = 1
 

--- a/src/defs.asm
+++ b/src/defs.asm
@@ -703,6 +703,16 @@ Enemy_BossMushroom = $7F
 
 ; ---------------------------------------------------------------------------
 
+LevelDirection_Horizontal = 1
+LevelDirection_Vertical = 0
+
+LevelMusic_Overworld = 0
+LevelMusic_Underground = 1
+LevelMusic_Boss = 2
+LevelMusic_Wart = 3
+
+; ---------------------------------------------------------------------------
+
 ; enum CollisionFlags (bitfield) (width 1 byte)
 CollisionFlags_00 = %00000000
 CollisionFlags_Right = %00000001

--- a/src/levels/1/1-1/1-1-area0.asm
+++ b/src/levels/1/1-1/1-1-area0.asm
@@ -1,7 +1,8 @@
 ; Level 1-1, Area 0
 
 LevelData_1_1_Area0:
-	.db $09, $F3, $30, $00
+	levelHeader 3, LevelDirection_Vertical, 1, 1, LevelMusic_Overworld, 0, 0, $13, $0
+
 	.db $B7, $0A
 IFNDEF DISABLE_DOOR_POINTERS
 	.db $00, $00

--- a/src/levels/1/1-1/1-1-area1.asm
+++ b/src/levels/1/1-1/1-1-area1.asm
@@ -1,7 +1,8 @@
 ; Level 1-1, Area 1
 
 LevelData_1_1_Area1:
-	.db $00, $F3, $30, $00
+	levelHeader 3, LevelDirection_Vertical, 0, 0, LevelMusic_Overworld, 0, 0, $13, $0
+
 	.db $F5, $00, $50
 	.db $34, $E1
 	.db $19, $E2

--- a/src/levels/1/1-1/1-1-area2.asm
+++ b/src/levels/1/1-1/1-1-area2.asm
@@ -1,7 +1,8 @@
 ; Level 1-1, Area 2
 
 LevelData_1_1_Area2:
-	.db $80, $E0, $92, $00
+	levelHeader 9, LevelDirection_Horizontal, 0, 0, LevelMusic_Overworld, 0, 2, $00, $0
+
 	.db $79, $16
 	.db $10, $C2
 	.db $07, $16

--- a/src/levels/1/1-1/1-1-area3.asm
+++ b/src/levels/1/1-1/1-1-area3.asm
@@ -1,7 +1,8 @@
 ; Level 1-1, Area 3
 
 LevelData_1_1_Area3:
-	.db $91, $EA, $22, $11
+	levelHeader 2, LevelDirection_Horizontal, 2, 1, LevelMusic_Underground, 0, 2, $0a, $2
+
 	.db $47, $A8
 	.db $19, $25
 	.db $0B, $25

--- a/src/levels/1/1-1/1-1-area4.asm
+++ b/src/levels/1/1-1/1-1-area4.asm
@@ -1,7 +1,8 @@
 ; Level 1-1, Area 4
 
 LevelData_1_1_Area4:
-	.db $91, $EA, $22, $11
+	levelHeader 2, LevelDirection_Horizontal, 2, 1, LevelMusic_Underground, 0, 2, $0a, $2
+
 	.db $03, $F3
 	.db $97, $12
 	.db $F5, $00, $31

--- a/src/levels/1/1-1/1-1-area5.asm
+++ b/src/levels/1/1-1/1-1-area5.asm
@@ -1,7 +1,8 @@
 ; Level 1-1, Area 5
 
 LevelData_1_1_Area5:
-	.db $80, $E8, $40, $12
+	levelHeader 4, LevelDirection_Horizontal, 0, 0, LevelMusic_Boss, 0, 0, $08, $2
+
 	.db $7C, $10
 	.db $18, $0C
 	.db $F5, $00, $10

--- a/src/levels/1/1-2/1-2-area0.asm
+++ b/src/levels/1/1-2/1-2-area0.asm
@@ -1,7 +1,8 @@
 ; Level 1-2, Area 0
 
 LevelData_1_2_Area0:
-	.db $80, $EA, $70, $10
+	levelHeader 7, LevelDirection_Horizontal, 0, 0, LevelMusic_Overworld, 0, 0, $0a, $2
+
 	.db $8E, $C3
 	.db $3B, $C1
 	.db $F0, $CD

--- a/src/levels/1/1-2/1-2-area1.asm
+++ b/src/levels/1/1-2/1-2-area1.asm
@@ -1,7 +1,8 @@
 ; Level 1-2, Area 1
 
 LevelData_1_2_Area1:
-	.db $89, $EA, $32, $11
+	levelHeader 3, LevelDirection_Horizontal, 1, 1, LevelMusic_Underground, 0, 2, $0a, $2
+
 	.db $99, $29
 	.db $16, $29
 	.db $0C, $29

--- a/src/levels/1/1-2/1-2-area2.asm
+++ b/src/levels/1/1-2/1-2-area2.asm
@@ -1,7 +1,8 @@
 ; Level 1-2, Area 2
 
 LevelData_1_2_Area2:
-	.db $80, $E0, $20, $02
+	levelHeader 2, LevelDirection_Horizontal, 0, 0, LevelMusic_Boss, 0, 0, $00, $0
+
 	.db $00, $8C
 	.db $01, $8C
 	.db $02, $8C

--- a/src/levels/1/1-2/1-2-area3.asm
+++ b/src/levels/1/1-2/1-2-area3.asm
@@ -1,7 +1,8 @@
 ; Level 1-2, Area 3
 
 LevelData_1_2_Area3:
-	.db $18, $E3, $01, $01
+	levelHeader 0, LevelDirection_Vertical, 3, 0, LevelMusic_Underground, 0, 1, $03, $0
+
 	.db $64, $32
 	.db $09, $32
 	.db $32, $32

--- a/src/levels/1/1-2/1-2-area4.asm
+++ b/src/levels/1/1-2/1-2-area4.asm
@@ -1,7 +1,8 @@
 ; Level 1-2, Area 4
 
 LevelData_1_2_Area4:
-	.db $18, $E3, $01, $01
+	levelHeader 0, LevelDirection_Vertical, 3, 0, LevelMusic_Underground, 0, 1, $03, $0
+
 	.db $64, $32
 	.db $09, $32
 	.db $32, $32

--- a/src/levels/1/1-3/1-3-area0.asm
+++ b/src/levels/1/1-3/1-3-area0.asm
@@ -1,7 +1,8 @@
 ; Level 1-3, Area 0
 
 LevelData_1_3_Area0:
-	.db $80, $E1, $90, $00
+	levelHeader 9, LevelDirection_Horizontal, 0, 0, LevelMusic_Overworld, 0, 0, $01, $0
+
 	.db $00, $8A
 	.db $01, $8A
 	.db $02, $8A

--- a/src/levels/1/1-3/1-3-area1.asm
+++ b/src/levels/1/1-3/1-3-area1.asm
@@ -1,7 +1,8 @@
 ; Level 1-3, Area 1
 
 LevelData_1_3_Area1:
-	.db $20, $E0, $03, $19
+	levelHeader 0, LevelDirection_Vertical, 4, 0, LevelMusic_Underground, 0, 3, $00, $3
+
 	.db $55, $2C
 	.db $0B, $2C
 	.db $33, $2C

--- a/src/levels/1/1-3/1-3-area2.asm
+++ b/src/levels/1/1-3/1-3-area2.asm
@@ -1,7 +1,8 @@
 ; Level 1-3, Area 2
 
 LevelData_1_3_Area2:
-	.db $20, $E0, $67, $19
+	levelHeader 6, LevelDirection_Vertical, 4, 0, LevelMusic_Underground, 1, 3, $00, $3
+
 	.db $58, $0A
 IFNDEF DISABLE_DOOR_POINTERS
 	.db $02, $10

--- a/src/levels/1/1-3/1-3-area3.asm
+++ b/src/levels/1/1-3/1-3-area3.asm
@@ -1,7 +1,8 @@
 ; Level 1-3, Area 3
 
 LevelData_1_3_Area3:
-	.db $A0, $EA, $57, $19
+	levelHeader 5, LevelDirection_Horizontal, 4, 0, LevelMusic_Underground, 1, 3, $0a, $3
+
 	.db $39, $29
 	.db $13, $13
 IFNDEF DISABLE_DOOR_POINTERS

--- a/src/levels/1/1-3/1-3-area4.asm
+++ b/src/levels/1/1-3/1-3-area4.asm
@@ -1,7 +1,8 @@
 ; Level 1-3, Area 4
 
 LevelData_1_3_Area4:
-	.db $AA, $F8, $16, $22
+	levelHeader 1, LevelDirection_Horizontal, 5, 2, LevelMusic_Boss, 1, 2, $18, $4
+
 	.db $6E, $25
 	.db $0F, $25
 	.db $1E, $32

--- a/src/levels/2/2-1/2-1-area0.asm
+++ b/src/levels/2/2-1/2-1-area0.asm
@@ -1,7 +1,8 @@
 ; Level 2-1, Area 0
 
 LevelData_2_1_Area0:
-	.db $80, $EC, $90, $00
+	levelHeader 9, LevelDirection_Horizontal, 0, 0, LevelMusic_Overworld, 0, 0, $0c, $0
+
 	.db $00, $0E
 	.db $14, $11
 	.db $12, $10

--- a/src/levels/2/2-1/2-1-area1.asm
+++ b/src/levels/2/2-1/2-1-area1.asm
@@ -1,7 +1,8 @@
 ; Level 2-1, Area 1
 
 LevelData_2_1_Area1:
-	.db $09, $F6, $31, $09
+	levelHeader 3, LevelDirection_Vertical, 1, 1, LevelMusic_Underground, 0, 1, $16, $1
+
 	.db $66, $13
 IFNDEF DISABLE_DOOR_POINTERS
 	.db $03, $09

--- a/src/levels/2/2-1/2-1-area2.asm
+++ b/src/levels/2/2-1/2-1-area2.asm
@@ -1,7 +1,8 @@
 ; Level 2-1, Area 2
 
 LevelData_2_1_Area2:
-	.db $91, $EA, $20, $1A
+	levelHeader 2, LevelDirection_Horizontal, 2, 1, LevelMusic_Boss, 0, 0, $0a, $3
+
 	.db $97, $80
 	.db $23, $0A
 IFNDEF DISABLE_DOOR_POINTERS

--- a/src/levels/2/2-1/2-1-area4.asm
+++ b/src/levels/2/2-1/2-1-area4.asm
@@ -1,7 +1,8 @@
 ; Level 2-1, Area 4
 
 LevelData_2_1_Area4:
-	.db $18, $E3, $01, $01
+	levelHeader 0, LevelDirection_Vertical, 3, 0, LevelMusic_Underground, 0, 1, $03, $0
+
 	.db $54, $32
 	.db $09, $32
 	.db $15, $30

--- a/src/levels/2/2-2/2-2-area0.asm
+++ b/src/levels/2/2-2/2-2-area0.asm
@@ -1,7 +1,8 @@
 ; Level 2-2, Area 0
 
 LevelData_2_2_Area0:
-	.db $89, $EA, $10, $19
+	levelHeader 1, LevelDirection_Horizontal, 1, 1, LevelMusic_Underground, 0, 0, $0a, $3
+
 	.db $8E, $81
 	.db $0F, $81
 	.db $F0, $B0

--- a/src/levels/2/2-2/2-2-area1.asm
+++ b/src/levels/2/2-2/2-2-area1.asm
@@ -1,7 +1,8 @@
 ; Level 2-2, Area 1
 
 LevelData_2_2_Area1:
-	.db $80, $EA, $90, $18
+	levelHeader 9, LevelDirection_Horizontal, 0, 0, LevelMusic_Overworld, 0, 0, $0a, $3
+
 	.db $2D, $10
 	.db $1B, $11
 	.db $56, $16

--- a/src/levels/2/2-2/2-2-area2.asm
+++ b/src/levels/2/2-2/2-2-area2.asm
@@ -1,7 +1,8 @@
 ; Level 2-2, Area 2
 
 LevelData_2_2_Area2:
-	.db $89, $EA, $20, $19
+	levelHeader 2, LevelDirection_Horizontal, 1, 1, LevelMusic_Underground, 0, 0, $0a, $3
+
 	.db $8B, $28
 	.db $0D, $26
 	.db $0E, $2D

--- a/src/levels/2/2-2/2-2-area3.asm
+++ b/src/levels/2/2-2/2-2-area3.asm
@@ -1,7 +1,8 @@
 ; Level 2-2, Area 3
 
 LevelData_2_2_Area3:
-	.db $09, $F2, $31, $09
+	levelHeader 3, LevelDirection_Vertical, 1, 1, LevelMusic_Underground, 0, 1, $12, $1
+
 	.db $02, $8A
 	.db $03, $8A
 	.db $04, $8A

--- a/src/levels/2/2-2/2-2-area4.asm
+++ b/src/levels/2/2-2/2-2-area4.asm
@@ -1,7 +1,8 @@
 ; Level 2-2, Area 4
 
 LevelData_2_2_Area4:
-	.db $18, $E3, $01, $01
+	levelHeader 0, LevelDirection_Vertical, 3, 0, LevelMusic_Underground, 0, 1, $03, $0
+
 	.db $54, $32
 	.db $09, $32
 	.db $15, $30

--- a/src/levels/2/2-2/2-2-area5.asm
+++ b/src/levels/2/2-2/2-2-area5.asm
@@ -1,7 +1,8 @@
 ; Level 2-2, Area 5
 
 LevelData_2_2_Area5:
-	.db $89, $EA, $22, $1A
+	levelHeader 2, LevelDirection_Horizontal, 1, 1, LevelMusic_Boss, 0, 2, $0a, $3
+
 	.db $43, $0A
 IFNDEF DISABLE_DOOR_POINTERS
 	.db $04, $33

--- a/src/levels/2/2-3/2-3-area0.asm
+++ b/src/levels/2/2-3/2-3-area0.asm
@@ -1,7 +1,8 @@
 ; Level 2-3, Area 0
 
 LevelData_2_3_Area0:
-	.db $89, $EA, $00, $01
+	levelHeader 0, LevelDirection_Horizontal, 1, 1, LevelMusic_Underground, 0, 0, $0a, $0
+
 	.db $09, $A9
 	.db $F5, $05, $11
 	.db $F0, $2F

--- a/src/levels/2/2-3/2-3-area1.asm
+++ b/src/levels/2/2-3/2-3-area1.asm
@@ -1,7 +1,8 @@
 ; Level 2-3, Area 1
 
 LevelData_2_3_Area1:
-	.db $80, $EC, $90, $00
+	levelHeader 9, LevelDirection_Horizontal, 0, 0, LevelMusic_Overworld, 0, 0, $0c, $0
+
 	.db $00, $89
 	.db $01, $89
 	.db $02, $89

--- a/src/levels/2/2-3/2-3-area2.asm
+++ b/src/levels/2/2-3/2-3-area2.asm
@@ -1,7 +1,8 @@
 ; Level 2-3, Area 2
 
 LevelData_2_3_Area2:
-	.db $91, $EA, $10, $19
+	levelHeader 1, LevelDirection_Horizontal, 2, 1, LevelMusic_Underground, 0, 0, $0a, $3
+
 	.db $8A, $2D
 	.db $0D, $13
 IFNDEF DISABLE_DOOR_POINTERS

--- a/src/levels/2/2-3/2-3-area3.asm
+++ b/src/levels/2/2-3/2-3-area3.asm
@@ -1,7 +1,8 @@
 ; Level 2-3, Area 3
 
 LevelData_2_3_Area3:
-	.db $09, $E1, $61, $09
+	levelHeader 6, LevelDirection_Vertical, 1, 1, LevelMusic_Underground, 0, 1, $01, $1
+
 	.db $68, $14
 IFNDEF DISABLE_DOOR_POINTERS
 	.db $05, $19

--- a/src/levels/2/2-3/2-3-area4.asm
+++ b/src/levels/2/2-3/2-3-area4.asm
@@ -1,7 +1,8 @@
 ; Level 2-3, Area 4
 
 LevelData_2_3_Area4:
-	.db $18, $E3, $01, $01
+	levelHeader 0, LevelDirection_Vertical, 3, 0, LevelMusic_Underground, 0, 1, $03, $0
+
 	.db $54, $31
 	.db $0A, $31
 	.db $15, $31

--- a/src/levels/2/2-3/2-3-area5.asm
+++ b/src/levels/2/2-3/2-3-area5.asm
@@ -1,7 +1,8 @@
 ; Level 2-3, Area 5
 
 LevelData_2_3_Area5:
-	.db $89, $EA, $62, $1A
+	levelHeader 6, LevelDirection_Horizontal, 1, 1, LevelMusic_Boss, 0, 2, $0a, $3
+
 	.db $43, $0A
 IFNDEF DISABLE_DOOR_POINTERS
 	.db $05, $33

--- a/src/levels/2/2-3/2-3-area6.asm
+++ b/src/levels/2/2-3/2-3-area6.asm
@@ -1,7 +1,8 @@
 ; Level 2-3, Area 6
 
 LevelData_2_3_Area6:
-	.db $AA, $EA, $13, $2A
+	levelHeader 1, LevelDirection_Horizontal, 5, 2, LevelMusic_Boss, 0, 3, $0a, $5
+
 	.db $8E, $30
 	.db $F0, $CD
 	.db $F1, $52

--- a/src/levels/2/2-3/2-3-area7.asm
+++ b/src/levels/2/2-3/2-3-area7.asm
@@ -1,7 +1,8 @@
 ; Level 2-3, Area 7
 
 LevelData_2_3_Area7:
-	.db $09, $E0, $03, $11
+	levelHeader 0, LevelDirection_Vertical, 1, 1, LevelMusic_Underground, 0, 3, $00, $2
+
 	.db $32, $2C
 	.db $0D, $2C
 	.db $22, $2C

--- a/src/levels/3/3-1/3-1-area0.asm
+++ b/src/levels/3/3-1/3-1-area0.asm
@@ -1,7 +1,8 @@
 ; Level 3-1, Area 0
 
 LevelData_3_1_Area0:
-	.db $80, $EA, $10, $10
+	levelHeader 1, LevelDirection_Horizontal, 0, 0, LevelMusic_Overworld, 0, 0, $0a, $2
+
 	.db $13, $10
 	.db $14, $11
 	.db $1A, $16

--- a/src/levels/3/3-1/3-1-area1.asm
+++ b/src/levels/3/3-1/3-1-area1.asm
@@ -1,7 +1,8 @@
 ; Level 3-1, Area 1
 
 LevelData_3_1_Area1:
-	.db $00, $F3, $90, $08
+	levelHeader 9, LevelDirection_Vertical, 0, 0, LevelMusic_Overworld, 0, 0, $13, $1
+
 	.db $6C, $10
 	.db $52, $10
 	.db $18, $12

--- a/src/levels/3/3-1/3-1-area2.asm
+++ b/src/levels/3/3-1/3-1-area2.asm
@@ -1,7 +1,8 @@
 ; Level 3-1, Area 2
 
 LevelData_3_1_Area2:
-	.db $89, $EA, $20, $11
+	levelHeader 2, LevelDirection_Horizontal, 1, 1, LevelMusic_Underground, 0, 0, $0a, $2
+
 	.db $87, $13
 IFNDEF DISABLE_DOOR_POINTERS
 	.db $06, $19

--- a/src/levels/3/3-1/3-1-area3.asm
+++ b/src/levels/3/3-1/3-1-area3.asm
@@ -1,7 +1,8 @@
 ; Level 3-1, Area 3
 
 LevelData_3_1_Area3:
-	.db $80, $E8, $53, $10
+	levelHeader 5, LevelDirection_Horizontal, 0, 0, LevelMusic_Overworld, 0, 3, $08, $2
+
 	.db $56, $10
 	.db $2A, $11
 	.db $2E, $10

--- a/src/levels/3/3-1/3-1-area4.asm
+++ b/src/levels/3/3-1/3-1-area4.asm
@@ -1,7 +1,8 @@
 ; Level 3-1, Area 4
 
 LevelData_3_1_Area4:
-	.db $91, $EA, $32, $12
+	levelHeader 3, LevelDirection_Horizontal, 2, 1, LevelMusic_Boss, 0, 2, $0a, $2
+
 	.db $41, $13
 IFNDEF DISABLE_DOOR_POINTERS
 	.db $06, $35

--- a/src/levels/3/3-2/3-2-area0.asm
+++ b/src/levels/3/3-2/3-2-area0.asm
@@ -1,7 +1,8 @@
 ; Level 3-2, Area 0
 
 LevelData_3_2_Area0:
-	.db $80, $EA, $98, $10
+	levelHeader 9, LevelDirection_Horizontal, 0, 0, LevelMusic_Overworld, 2, 0, $0a, $2
+
 	.db $2F, $16
 	.db $9C, $0A
 IFNDEF DISABLE_DOOR_POINTERS

--- a/src/levels/3/3-2/3-2-area1.asm
+++ b/src/levels/3/3-2/3-2-area1.asm
@@ -1,7 +1,8 @@
 ; Level 3-2, Area 1
 
 LevelData_3_2_Area1:
-	.db $91, $EA, $72, $11
+	levelHeader 7, LevelDirection_Horizontal, 2, 1, LevelMusic_Underground, 0, 2, $0a, $2
+
 	.db $97, $25
 	.db $09, $21
 	.db $0B, $21

--- a/src/levels/3/3-2/3-2-area2.asm
+++ b/src/levels/3/3-2/3-2-area2.asm
@@ -1,7 +1,8 @@
 ; Level 3-2, Area 2
 
 LevelData_3_2_Area2:
-	.db $91, $EA, $30, $12
+	levelHeader 3, LevelDirection_Horizontal, 2, 1, LevelMusic_Boss, 0, 0, $0a, $2
+
 	.db $83, $00
 	.db $04, $00
 	.db $05, $00

--- a/src/levels/3/3-3/3-3-area0.asm
+++ b/src/levels/3/3-3/3-3-area0.asm
@@ -1,7 +1,8 @@
 ; Level 3-3, Area 0
 
 LevelData_3_3_Area0:
-	.db $91, $EA, $10, $11
+	levelHeader 1, LevelDirection_Horizontal, 2, 1, LevelMusic_Underground, 0, 0, $0a, $2
+
 	.db $F0, $94
 	.db $F2
 	.db $48, $13

--- a/src/levels/3/3-3/3-3-area1.asm
+++ b/src/levels/3/3-3/3-3-area1.asm
@@ -1,7 +1,8 @@
 ; Level 3-3, Area 1
 
 LevelData_3_3_Area1:
-	.db $80, $E1, $30, $00
+	levelHeader 3, LevelDirection_Horizontal, 0, 0, LevelMusic_Overworld, 0, 0, $01, $0
+
 	.db $35, $10
 	.db $29, $11
 	.db $36, $C2

--- a/src/levels/3/3-3/3-3-area2.asm
+++ b/src/levels/3/3-3/3-3-area2.asm
@@ -1,7 +1,8 @@
 ; Level 3-3, Area 2
 
 LevelData_3_3_Area2:
-	.db $A0, $EA, $33, $19
+	levelHeader 3, LevelDirection_Horizontal, 4, 0, LevelMusic_Underground, 0, 3, $0a, $3
+
 	.db $55, $01
 	.db $0B, $2D
 	.db $6C, $09

--- a/src/levels/3/3-3/3-3-area3.asm
+++ b/src/levels/3/3-3/3-3-area3.asm
@@ -1,7 +1,8 @@
 ; Level 3-3, Area 3
 
 LevelData_3_3_Area3:
-	.db $20, $E0, $93, $19
+	levelHeader 9, LevelDirection_Vertical, 4, 0, LevelMusic_Underground, 0, 3, $00, $3
+
 	.db $15, $AB
 	.db $18, $0A
 IFNDEF DISABLE_DOOR_POINTERS

--- a/src/levels/3/3-3/3-3-area4.asm
+++ b/src/levels/3/3-3/3-3-area4.asm
@@ -1,7 +1,8 @@
 ; Level 3-3, Area 4
 
 LevelData_3_3_Area4:
-	.db $20, $E0, $67, $19
+	levelHeader 6, LevelDirection_Vertical, 4, 0, LevelMusic_Underground, 1, 3, $00, $3
+
 	.db $AE, $30
 	.db $12, $0A
 IFNDEF DISABLE_DOOR_POINTERS

--- a/src/levels/3/3-3/3-3-area5.asm
+++ b/src/levels/3/3-3/3-3-area5.asm
@@ -1,7 +1,8 @@
 ; Level 3-3, Area 5
 
 LevelData_3_3_Area5:
-	.db $20, $E0, $37, $19
+	levelHeader 3, LevelDirection_Vertical, 4, 0, LevelMusic_Underground, 1, 3, $00, $3
+
 	.db $A0, $37
 	.db $1B, $0A
 IFNDEF DISABLE_DOOR_POINTERS

--- a/src/levels/3/3-3/3-3-area6.asm
+++ b/src/levels/3/3-3/3-3-area6.asm
@@ -1,7 +1,8 @@
 ; Level 3-3, Area 6
 
 LevelData_3_3_Area6:
-	.db $20, $E0, $07, $19
+	levelHeader 0, LevelDirection_Vertical, 4, 0, LevelMusic_Underground, 1, 3, $00, $3
+
 	.db $54, $2C
 	.db $0C, $2C
 	.db $57, $32

--- a/src/levels/3/3-3/3-3-area7.asm
+++ b/src/levels/3/3-3/3-3-area7.asm
@@ -1,7 +1,8 @@
 ; Level 3-3, Area 7
 
 LevelData_3_3_Area7:
-	.db $80, $FD, $40, $1A
+	levelHeader 4, LevelDirection_Horizontal, 0, 0, LevelMusic_Boss, 0, 0, $1d, $3
+
 	.db $3A, $10
 	.db $27, $11
 	.db $35, $34

--- a/src/levels/3/3-3/3-3-area8.asm
+++ b/src/levels/3/3-3/3-3-area8.asm
@@ -1,7 +1,8 @@
 ; Level 3-3, Area 8
 
 LevelData_3_3_Area8:
-	.db $AA, $F8, $17, $22
+	levelHeader 1, LevelDirection_Horizontal, 5, 2, LevelMusic_Boss, 1, 3, $18, $4
+
 	.db $6E, $A4
 	.db $F0, $5C
 	.db $F0, $DD

--- a/src/levels/4/4-1/4-1-area0.asm
+++ b/src/levels/4/4-1/4-1-area0.asm
@@ -1,7 +1,8 @@
 ; Level 4-1, Area 0
 
 LevelData_4_1_Area0:
-	.db $80, $EA, $90, $10
+	levelHeader 9, LevelDirection_Horizontal, 0, 0, LevelMusic_Overworld, 0, 0, $0a, $2
+
 	.db $2C, $10
 	.db $1E, $11
 	.db $44, $39

--- a/src/levels/4/4-1/4-1-area1.asm
+++ b/src/levels/4/4-1/4-1-area1.asm
@@ -1,7 +1,8 @@
 ; Level 4-1, Area 1
 
 LevelData_4_1_Area1:
-	.db $80, $E8, $90, $12
+	levelHeader 9, LevelDirection_Horizontal, 0, 0, LevelMusic_Boss, 0, 0, $08, $2
+
 	.db $22, $10
 	.db $17, $11
 	.db $52, $39

--- a/src/levels/4/4-2/4-2-area0.asm
+++ b/src/levels/4/4-2/4-2-area0.asm
@@ -1,7 +1,8 @@
 ; Level 4-2, Area 0
 
 LevelData_4_2_Area0:
-	.db $80, $EA, $10, $10
+	levelHeader 1, LevelDirection_Horizontal, 0, 0, LevelMusic_Overworld, 0, 0, $0a, $2
+
 	.db $AC, $3C
 	.db $F0, $8C
 	.db $F1, $88

--- a/src/levels/4/4-2/4-2-area1.asm
+++ b/src/levels/4/4-2/4-2-area1.asm
@@ -1,7 +1,8 @@
 ; Level 4-2, Area 1
 
 LevelData_4_2_Area1:
-	.db $80, $E8, $90, $10
+	levelHeader 9, LevelDirection_Horizontal, 0, 0, LevelMusic_Overworld, 0, 0, $08, $2
+
 	.db $32, $10
 	.db $14, $11
 	.db $17, $0C

--- a/src/levels/4/4-2/4-2-area2.asm
+++ b/src/levels/4/4-2/4-2-area2.asm
@@ -1,7 +1,8 @@
 ; Level 4-2, Area 2
 
 LevelData_4_2_Area2:
-	.db $80, $F6, $90, $28
+	levelHeader 9, LevelDirection_Horizontal, 0, 0, LevelMusic_Overworld, 0, 0, $16, $5
+
 	.db $4C, $10
 	.db $1E, $11
 	.db $49, $26

--- a/src/levels/4/4-2/4-2-area3.asm
+++ b/src/levels/4/4-2/4-2-area3.asm
@@ -1,7 +1,8 @@
 ; Level 4-2, Area 3
 
 LevelData_4_2_Area3:
-	.db $80, $E8, $30, $30
+	levelHeader 3, LevelDirection_Horizontal, 0, 0, LevelMusic_Overworld, 0, 0, $08, $6
+
 	.db $28, $10
 	.db $1C, $11
 	.db $52, $39

--- a/src/levels/4/4-2/4-2-area4.asm
+++ b/src/levels/4/4-2/4-2-area4.asm
@@ -1,7 +1,8 @@
 ; Level 4-2, Area 4
 
 LevelData_4_2_Area4:
-	.db $91, $EA, $20, $32
+	levelHeader 2, LevelDirection_Horizontal, 2, 1, LevelMusic_Boss, 0, 0, $0a, $6
+
 	.db $81, $13
 IFNDEF DISABLE_DOOR_POINTERS
 	.db $0A, $33

--- a/src/levels/4/4-3/4-3-area0.asm
+++ b/src/levels/4/4-3/4-3-area0.asm
@@ -1,7 +1,8 @@
 ; Level 4-3, Area 0
 
 LevelData_4_3_Area0:
-	.db $91, $EA, $02, $11
+	levelHeader 0, LevelDirection_Horizontal, 2, 1, LevelMusic_Underground, 0, 2, $0a, $2
+
 	.db $4B, $14
 IFNDEF DISABLE_DOOR_POINTERS
 	.db $0B, $11

--- a/src/levels/4/4-3/4-3-area1.asm
+++ b/src/levels/4/4-3/4-3-area1.asm
@@ -1,7 +1,8 @@
 ; Level 4-3, Area 1
 
 LevelData_4_3_Area1:
-	.db $80, $E1, $91, $00
+	levelHeader 9, LevelDirection_Horizontal, 0, 0, LevelMusic_Overworld, 0, 1, $01, $0
+
 	.db $00, $8A
 	.db $2A, $10
 	.db $1D, $11

--- a/src/levels/4/4-3/4-3-area2.asm
+++ b/src/levels/4/4-3/4-3-area2.asm
@@ -1,7 +1,8 @@
 ; Level 4-3, Area 2
 
 LevelData_4_3_Area2:
-	.db $20, $E0, $60, $09
+	levelHeader 6, LevelDirection_Vertical, 4, 0, LevelMusic_Underground, 0, 0, $00, $1
+
 	.db $44, $0A
 IFNDEF DISABLE_DOOR_POINTERS
 	.db $0B, $41

--- a/src/levels/4/4-3/4-3-area3.asm
+++ b/src/levels/4/4-3/4-3-area3.asm
@@ -1,7 +1,8 @@
 ; Level 4-3, Area 3
 
 LevelData_4_3_Area3:
-	.db $20, $E0, $62, $09
+	levelHeader 6, LevelDirection_Vertical, 4, 0, LevelMusic_Underground, 0, 2, $00, $1
+
 	.db $37, $0A
 IFNDEF DISABLE_DOOR_POINTERS
 	.db $0B, $42

--- a/src/levels/4/4-3/4-3-area4.asm
+++ b/src/levels/4/4-3/4-3-area4.asm
@@ -1,7 +1,8 @@
 ; Level 4-3, Area 4
 
 LevelData_4_3_Area4:
-	.db $80, $E8, $32, $18
+	levelHeader 3, LevelDirection_Horizontal, 0, 0, LevelMusic_Overworld, 0, 2, $08, $3
+
 	.db $5D, $E2
 	.db $4F, $E1
 	.db $91, $41

--- a/src/levels/4/4-3/4-3-area5.asm
+++ b/src/levels/4/4-3/4-3-area5.asm
@@ -1,7 +1,8 @@
 ; Level 4-3, Area 5
 
 LevelData_4_3_Area5:
-	.db $20, $E0, $02, $09
+	levelHeader 0, LevelDirection_Vertical, 4, 0, LevelMusic_Underground, 0, 2, $00, $1
+
 	.db $56, $32
 	.db $34, $36
 	.db $27, $0A

--- a/src/levels/4/4-3/4-3-area6.asm
+++ b/src/levels/4/4-3/4-3-area6.asm
@@ -1,7 +1,8 @@
 ; Level 4-3, Area 6
 
 LevelData_4_3_Area6:
-	.db $A0, $EA, $10, $1A
+	levelHeader 1, LevelDirection_Horizontal, 4, 0, LevelMusic_Boss, 0, 0, $0a, $3
+
 	.db $62, $3D
 	.db $46, $0A
 IFNDEF DISABLE_DOOR_POINTERS

--- a/src/levels/4/4-3/4-3-area7.asm
+++ b/src/levels/4/4-3/4-3-area7.asm
@@ -1,7 +1,8 @@
 ; Level 4-3, Area 7
 
 LevelData_4_3_Area7:
-	.db $2A, $F5, $0F, $12
+	levelHeader 0, LevelDirection_Vertical, 5, 2, LevelMusic_Boss, 3, 3, $15, $2
+
 	.db $54, $32
 	.db $09, $32
 	.db $07, $00

--- a/src/levels/5/5-1/5-1-area0.asm
+++ b/src/levels/5/5-1/5-1-area0.asm
@@ -1,7 +1,8 @@
 ; Level 5-1, Area 0
 
 LevelData_5_1_Area0:
-	.db $81, $E2, $20, $00
+	levelHeader 2, LevelDirection_Horizontal, 0, 1, LevelMusic_Overworld, 0, 0, $02, $0
+
 	.db $00, $86
 	.db $01, $86
 	.db $02, $86

--- a/src/levels/5/5-1/5-1-area1.asm
+++ b/src/levels/5/5-1/5-1-area1.asm
@@ -1,7 +1,8 @@
 ; Level 5-1, Area 1
 
 LevelData_5_1_Area1:
-	.db $91, $EA, $80, $11
+	levelHeader 8, LevelDirection_Horizontal, 2, 1, LevelMusic_Underground, 0, 0, $0a, $2
+
 	.db $83, $13
 IFNDEF DISABLE_DOOR_POINTERS
 	.db $0C, $01

--- a/src/levels/5/5-1/5-1-area2.asm
+++ b/src/levels/5/5-1/5-1-area2.asm
@@ -1,7 +1,8 @@
 ; Level 5-1, Area 2
 
 LevelData_5_1_Area2:
-	.db $91, $F0, $13, $12
+	levelHeader 1, LevelDirection_Horizontal, 2, 1, LevelMusic_Boss, 0, 3, $10, $2
+
 	.db $6B, $32
 	.db $51, $0B
 IFNDEF DISABLE_DOOR_POINTERS

--- a/src/levels/5/5-2/5-2-area0.asm
+++ b/src/levels/5/5-2/5-2-area0.asm
@@ -1,7 +1,8 @@
 ; Level 5-2, Area 0
 
 LevelData_5_2_Area0:
-	.db $91, $EA, $10, $11
+	levelHeader 1, LevelDirection_Horizontal, 2, 1, LevelMusic_Underground, 0, 0, $0a, $2
+
 	.db $F0, $5B
 	.db $F2
 	.db $F0, $11

--- a/src/levels/5/5-2/5-2-area1.asm
+++ b/src/levels/5/5-2/5-2-area1.asm
@@ -1,7 +1,8 @@
 ; Level 5-2, Area 1
 
 LevelData_5_2_Area1:
-	.db $81, $E0, $90, $00
+	levelHeader 9, LevelDirection_Horizontal, 0, 1, LevelMusic_Overworld, 0, 0, $00, $0
+
 	.db $24, $10
 	.db $17, $11
 	.db $59, $2A

--- a/src/levels/5/5-2/5-2-area2.asm
+++ b/src/levels/5/5-2/5-2-area2.asm
@@ -1,7 +1,8 @@
 ; Level 5-2, Area 2
 
 LevelData_5_2_Area2:
-	.db $01, $F3, $30, $28
+	levelHeader 3, LevelDirection_Vertical, 0, 1, LevelMusic_Overworld, 0, 0, $13, $5
+
 	.db $0F, $85
 	.db $48, $0C
 	.db $4E, $0B

--- a/src/levels/5/5-2/5-2-area3.asm
+++ b/src/levels/5/5-2/5-2-area3.asm
@@ -1,7 +1,8 @@
 ; Level 5-2, Area 3
 
 LevelData_5_2_Area3:
-	.db $01, $F5, $60, $29
+	levelHeader 6, LevelDirection_Vertical, 0, 1, LevelMusic_Underground, 0, 0, $15, $5
+
 	.db $14, $10
 	.db $2C, $11
 	.db $11, $0B

--- a/src/levels/5/5-2/5-2-area4.asm
+++ b/src/levels/5/5-2/5-2-area4.asm
@@ -1,7 +1,8 @@
 ; Level 5-2, Area 4
 
 LevelData_5_2_Area4:
-	.db $18, $E3, $11, $01
+	levelHeader 1, LevelDirection_Vertical, 3, 0, LevelMusic_Underground, 0, 1, $03, $0
+
 	.db $F5, $0D, $13
 	.db $64, $31
 	.db $0A, $31

--- a/src/levels/5/5-2/5-2-area5.asm
+++ b/src/levels/5/5-2/5-2-area5.asm
@@ -1,7 +1,8 @@
 ; Level 5-2, Area 5
 
 LevelData_5_2_Area5:
-	.db $81, $EA, $20, $12
+	levelHeader 2, LevelDirection_Horizontal, 0, 1, LevelMusic_Boss, 0, 0, $0a, $2
+
 	.db $82, $0B
 IFNDEF DISABLE_DOOR_POINTERS
 	.db $0D, $36

--- a/src/levels/5/5-3/5-3-area0.asm
+++ b/src/levels/5/5-3/5-3-area0.asm
@@ -1,7 +1,8 @@
 ; Level 5-3, Area 0
 
 LevelData_5_3_Area0:
-	.db $91, $EA, $10, $11
+	levelHeader 1, LevelDirection_Horizontal, 2, 1, LevelMusic_Underground, 0, 0, $0a, $2
+
 	.db $F0, $70
 	.db $F2
 	.db $09, $A9

--- a/src/levels/5/5-3/5-3-area1.asm
+++ b/src/levels/5/5-3/5-3-area1.asm
@@ -1,7 +1,8 @@
 ; Level 5-3, Area 1
 
 LevelData_5_3_Area1:
-	.db $81, $E8, $92, $00
+	levelHeader 9, LevelDirection_Horizontal, 0, 1, LevelMusic_Overworld, 0, 2, $08, $0
+
 	.db $22, $10
 	.db $16, $11
 	.db $28, $08

--- a/src/levels/5/5-3/5-3-area2.asm
+++ b/src/levels/5/5-3/5-3-area2.asm
@@ -1,7 +1,8 @@
 ; Level 5-3, Area 2
 
 LevelData_5_3_Area2:
-	.db $91, $EA, $42, $11
+	levelHeader 4, LevelDirection_Horizontal, 2, 1, LevelMusic_Underground, 0, 2, $0a, $2
+
 	.db $04, $1F
 	.db $7E, $D7
 	.db $18, $0B

--- a/src/levels/5/5-3/5-3-area3.asm
+++ b/src/levels/5/5-3/5-3-area3.asm
@@ -1,7 +1,8 @@
 ; Level 5-3, Area 3
 
 LevelData_5_3_Area3:
-	.db $18, $E0, $61, $11
+	levelHeader 6, LevelDirection_Vertical, 3, 0, LevelMusic_Underground, 0, 1, $00, $2
+
 	.db $68, $13
 IFNDEF DISABLE_DOOR_POINTERS
 	.db $0E, $40

--- a/src/levels/5/5-3/5-3-area4.asm
+++ b/src/levels/5/5-3/5-3-area4.asm
@@ -1,7 +1,8 @@
 ; Level 5-3, Area 4
 
 LevelData_5_3_Area4:
-	.db $81, $E8, $90, $12
+	levelHeader 9, LevelDirection_Horizontal, 0, 1, LevelMusic_Boss, 0, 0, $08, $2
+
 	.db $02, $1F
 	.db $67, $0B
 IFNDEF DISABLE_DOOR_POINTERS

--- a/src/levels/5/5-3/5-3-area5.asm
+++ b/src/levels/5/5-3/5-3-area5.asm
@@ -1,7 +1,8 @@
 ; Level 5-3, Area 5
 
 LevelData_5_3_Area5:
-	.db $AA, $EA, $12, $22
+	levelHeader 1, LevelDirection_Horizontal, 5, 2, LevelMusic_Boss, 0, 2, $0a, $4
+
 	.db $F0, $4F
 	.db $F0, $CC
 	.db $F1, $4F

--- a/src/levels/6/6-1/6-1-area0.asm
+++ b/src/levels/6/6-1/6-1-area0.asm
@@ -1,7 +1,8 @@
 ; Level 6-1, Area 0
 
 LevelData_6_1_Area0:
-	.db $80, $ED, $90, $18
+	levelHeader 9, LevelDirection_Horizontal, 0, 0, LevelMusic_Overworld, 0, 0, $0d, $3
+
 	.db $00, $8C
 	.db $01, $8C
 	.db $02, $8C

--- a/src/levels/6/6-1/6-1-area1.asm
+++ b/src/levels/6/6-1/6-1-area1.asm
@@ -1,7 +1,8 @@
 ; Level 6-1, Area 1
 
 LevelData_6_1_Area1:
-	.db $89, $EA, $30, $19
+	levelHeader 3, LevelDirection_Horizontal, 1, 1, LevelMusic_Underground, 0, 0, $0a, $3
+
 	.db $46, $13
 	.db $F5, $0F, $09
 	.db $2D, $81

--- a/src/levels/6/6-1/6-1-area2.asm
+++ b/src/levels/6/6-1/6-1-area2.asm
@@ -1,7 +1,8 @@
 ; Level 6-1, Area 2
 
 LevelData_6_1_Area2:
-	.db $89, $EA, $20, $1A
+	levelHeader 2, LevelDirection_Horizontal, 1, 1, LevelMusic_Boss, 0, 0, $0a, $3
+
 	.db $83, $13
 	.db $F5, $0F, $13
 	.db $F0, $51

--- a/src/levels/6/6-1/6-1-area3.asm
+++ b/src/levels/6/6-1/6-1-area3.asm
@@ -1,7 +1,8 @@
 ; Level 6-1, Area 3
 
 LevelData_6_1_Area3:
-	.db $18, $E3, $21, $19
+	levelHeader 2, LevelDirection_Vertical, 3, 0, LevelMusic_Underground, 0, 1, $03, $3
+
 	.db $F5, $0F, $12
 	.db $65, $31
 	.db $09, $31

--- a/src/levels/6/6-1/6-1-area4.asm
+++ b/src/levels/6/6-1/6-1-area4.asm
@@ -1,7 +1,8 @@
 ; Level 6-1, Area 4
 
 LevelData_6_1_Area4:
-	.db $18, $E3, $01, $01
+	levelHeader 0, LevelDirection_Vertical, 3, 0, LevelMusic_Underground, 0, 1, $03, $0
+
 	.db $64, $32
 	.db $09, $32
 	.db $34, $30

--- a/src/levels/6/6-1/6-1-area5.asm
+++ b/src/levels/6/6-1/6-1-area5.asm
@@ -1,7 +1,8 @@
 ; Level 6-1, Area 5
 
 LevelData_6_1_Area5:
-	.db $18, $E3, $21, $19
+	levelHeader 2, LevelDirection_Vertical, 3, 0, LevelMusic_Underground, 0, 1, $03, $3
+
 	.db $F5, $0F, $11
 	.db $65, $31
 	.db $09, $31

--- a/src/levels/6/6-1/6-1-area6.asm
+++ b/src/levels/6/6-1/6-1-area6.asm
@@ -1,7 +1,8 @@
 ; Level 6-1, Area 6
 
 LevelData_6_1_Area6:
-	.db $18, $E3, $01, $01
+	levelHeader 0, LevelDirection_Vertical, 3, 0, LevelMusic_Underground, 0, 1, $03, $0
+
 	.db $65, $31
 	.db $09, $31
 	.db $33, $31

--- a/src/levels/6/6-2/6-2-area0.asm
+++ b/src/levels/6/6-2/6-2-area0.asm
@@ -1,7 +1,8 @@
 ; Level 6-2, Area 0
 
 LevelData_6_2_Area0:
-	.db $91, $EA, $10, $19
+	levelHeader 1, LevelDirection_Horizontal, 2, 1, LevelMusic_Underground, 0, 0, $0a, $3
+
 	.db $F0, $54
 	.db $F1, $8F
 	.db $F2

--- a/src/levels/6/6-2/6-2-area1.asm
+++ b/src/levels/6/6-2/6-2-area1.asm
@@ -1,7 +1,8 @@
 ; Level 6-2, Area 1
 
 LevelData_6_2_Area1:
-	.db $91, $EA, $90, $18
+	levelHeader 9, LevelDirection_Horizontal, 2, 1, LevelMusic_Overworld, 0, 0, $0a, $3
+
 	.db $00, $0E
 	.db $93, $0B
 	.db $F5, $10, $01

--- a/src/levels/6/6-2/6-2-area2.asm
+++ b/src/levels/6/6-2/6-2-area2.asm
@@ -1,7 +1,8 @@
 ; Level 6-2, Area 2
 
 LevelData_6_2_Area2:
-	.db $91, $EA, $20, $1A
+	levelHeader 2, LevelDirection_Horizontal, 2, 1, LevelMusic_Boss, 0, 0, $0a, $3
+
 	.db $43, $13
 	.db $F5, $10, $19
 	.db $F0, $4E

--- a/src/levels/6/6-3/6-3-area0.asm
+++ b/src/levels/6/6-3/6-3-area0.asm
@@ -1,7 +1,8 @@
 ; Level 6-3, Area 0
 
 LevelData_6_3_Area0:
-	.db $89, $EA, $00, $01
+	levelHeader 0, LevelDirection_Horizontal, 1, 1, LevelMusic_Underground, 0, 0, $0a, $0
+
 	.db $07, $A9
 	.db $F5, $11, $11
 	.db $F0, $50

--- a/src/levels/6/6-3/6-3-area1.asm
+++ b/src/levels/6/6-3/6-3-area1.asm
@@ -1,7 +1,8 @@
 ; Level 6-3, Area 1
 
 LevelData_6_3_Area1:
-	.db $80, $EC, $40, $00
+	levelHeader 4, LevelDirection_Horizontal, 0, 0, LevelMusic_Overworld, 0, 0, $0c, $0
+
 	.db $00, $89
 	.db $01, $89
 	.db $0A, $89

--- a/src/levels/6/6-3/6-3-area2.asm
+++ b/src/levels/6/6-3/6-3-area2.asm
@@ -1,7 +1,8 @@
 ; Level 6-3, Area 2
 
 LevelData_6_3_Area2:
-	.db $91, $EA, $72, $19
+	levelHeader 7, LevelDirection_Horizontal, 2, 1, LevelMusic_Underground, 0, 2, $0a, $3
+
 	.db $65, $15
 	.db $06, $13
 	.db $F5, $11, $14

--- a/src/levels/6/6-3/6-3-area3.asm
+++ b/src/levels/6/6-3/6-3-area3.asm
@@ -1,7 +1,8 @@
 ; Level 6-3, Area 3
 
 LevelData_6_3_Area3:
-	.db $00, $F3, $90, $08
+	levelHeader 9, LevelDirection_Vertical, 0, 0, LevelMusic_Overworld, 0, 0, $13, $1
+
 	.db $34, $E1
 	.db $48, $E1
 	.db $67, $12

--- a/src/levels/6/6-3/6-3-area4.asm
+++ b/src/levels/6/6-3/6-3-area4.asm
@@ -1,7 +1,8 @@
 ; Level 6-3, Area 4
 
 LevelData_6_3_Area4:
-	.db $80, $E8, $40, $00
+	levelHeader 4, LevelDirection_Horizontal, 0, 0, LevelMusic_Overworld, 0, 0, $08, $0
+
 	.db $24, $10
 	.db $28, $0C
 	.db $F5, $11, $30

--- a/src/levels/6/6-3/6-3-area5.asm
+++ b/src/levels/6/6-3/6-3-area5.asm
@@ -1,7 +1,8 @@
 ; Level 6-3, Area 5
 
 LevelData_6_3_Area5:
-	.db $A0, $EA, $13, $22
+	levelHeader 1, LevelDirection_Horizontal, 4, 0, LevelMusic_Boss, 0, 3, $0a, $4
+
 	.db $86, $13
 	.db $F5, $11, $42
 	.db $F0, $AF

--- a/src/levels/6/6-3/6-3-area6.asm
+++ b/src/levels/6/6-3/6-3-area6.asm
@@ -1,7 +1,8 @@
 ; Level 6-3, Area 6
 
 LevelData_6_3_Area6:
-	.db $AA, $F8, $13, $2A
+	levelHeader 1, LevelDirection_Horizontal, 5, 2, LevelMusic_Boss, 0, 3, $18, $5
+
 	.db $F0, $50
 	.db $F0, $CD
 	.db $F1, $0C

--- a/src/levels/7/7-1/7-1-area0.asm
+++ b/src/levels/7/7-1/7-1-area0.asm
@@ -1,7 +1,8 @@
 ; Level 7-1, Area 0
 
 LevelData_7_1_Area0:
-	.db $00, $F3, $00, $00
+	levelHeader 0, LevelDirection_Vertical, 0, 0, LevelMusic_Overworld, 0, 0, $13, $0
+
 	.db $03, $A3
 	.db $F5, $12, $12
 	.db $43, $E5

--- a/src/levels/7/7-1/7-1-area1.asm
+++ b/src/levels/7/7-1/7-1-area1.asm
@@ -1,7 +1,8 @@
 ; Level 7-1, Area 1
 
 LevelData_7_1_Area1:
-	.db $80, $E8, $63, $00
+	levelHeader 6, LevelDirection_Horizontal, 0, 0, LevelMusic_Overworld, 0, 3, $08, $0
+
 	.db $27, $A9
 	.db $74, $23
 	.db $F5, $12, $20

--- a/src/levels/7/7-1/7-1-area2.asm
+++ b/src/levels/7/7-1/7-1-area2.asm
@@ -1,7 +1,8 @@
 ; Level 7-1, Area 2
 
 LevelData_7_1_Area2:
-	.db $80, $E8, $30, $00
+	levelHeader 3, LevelDirection_Horizontal, 0, 0, LevelMusic_Overworld, 0, 0, $08, $0
+
 	.db $3C, $11
 	.db $19, $10
 	.db $5F, $EB

--- a/src/levels/7/7-1/7-1-area3.asm
+++ b/src/levels/7/7-1/7-1-area3.asm
@@ -1,7 +1,8 @@
 ; Level 7-1, Area 3
 
 LevelData_7_1_Area3:
-	.db $00, $F3, $30, $00
+	levelHeader 3, LevelDirection_Vertical, 0, 0, LevelMusic_Overworld, 0, 0, $13, $0
+
 	.db $64, $A6
 	.db $0A, $A6
 	.db $22, $E1

--- a/src/levels/7/7-1/7-1-area4.asm
+++ b/src/levels/7/7-1/7-1-area4.asm
@@ -1,7 +1,8 @@
 ; Level 7-1, Area 4
 
 LevelData_7_1_Area4:
-	.db $A1, $EA, $10, $02
+	levelHeader 1, LevelDirection_Horizontal, 4, 1, LevelMusic_Boss, 0, 0, $0a, $0
+
 	.db $48, $0A
 	.db $F5, $12, $30
 	.db $0C, $33

--- a/src/levels/7/7-1/7-1-area5.asm
+++ b/src/levels/7/7-1/7-1-area5.asm
@@ -1,7 +1,8 @@
 ; Level 7-1, Area 5
 
 LevelData_7_1_Area5:
-	.db $A1, $EA, $00, $01
+	levelHeader 0, LevelDirection_Horizontal, 4, 1, LevelMusic_Underground, 0, 0, $0a, $0
+
 	.db $4C, $00
 	.db $21, $2D
 	.db $02, $21

--- a/src/levels/7/7-2/7-2-area0.asm
+++ b/src/levels/7/7-2/7-2-area0.asm
@@ -1,7 +1,8 @@
 ; Level 7-2, Area 0
 
 LevelData_7_2_Area0:
-	.db $80, $FF, $20, $00
+	levelHeader 2, LevelDirection_Horizontal, 0, 0, LevelMusic_Overworld, 0, 0, $1f, $0
+
 	.db $80, $E5
 	.db $0D, $E5
 	.db $2A, $E5

--- a/src/levels/7/7-2/7-2-area1.asm
+++ b/src/levels/7/7-2/7-2-area1.asm
@@ -1,7 +1,8 @@
 ; Level 7-2, Area 1
 
 LevelData_7_2_Area1:
-	.db $A1, $EA, $65, $01
+	levelHeader 6, LevelDirection_Horizontal, 4, 1, LevelMusic_Underground, 1, 1, $0a, $0
+
 	.db $87, $13
 	.db $F5, $13, $02
 	.db $22, $3D

--- a/src/levels/7/7-2/7-2-area2.asm
+++ b/src/levels/7/7-2/7-2-area2.asm
@@ -1,7 +1,8 @@
 ; Level 7-2, Area 2
 
 LevelData_7_2_Area2:
-	.db $A1, $EA, $95, $01
+	levelHeader 9, LevelDirection_Horizontal, 4, 1, LevelMusic_Underground, 1, 1, $0a, $0
+
 	.db $88, $0A
 	.db $F5, $13, $93
 	.db $13, $2B

--- a/src/levels/7/7-2/7-2-area3.asm
+++ b/src/levels/7/7-2/7-2-area3.asm
@@ -1,7 +1,8 @@
 ; Level 7-2, Area 3
 
 LevelData_7_2_Area3:
-	.db $A1, $EA, $34, $01
+	levelHeader 3, LevelDirection_Horizontal, 4, 1, LevelMusic_Underground, 1, 0, $0a, $0
+
 	.db $5C, $40
 	.db $1C, $A4
 	.db $25, $0A

--- a/src/levels/7/7-2/7-2-area4.asm
+++ b/src/levels/7/7-2/7-2-area4.asm
@@ -1,7 +1,8 @@
 ; Level 7-2, Area 4
 
 LevelData_7_2_Area4:
-	.db $A1, $EA, $95, $02
+	levelHeader 9, LevelDirection_Horizontal, 4, 1, LevelMusic_Boss, 1, 1, $0a, $0
+
 	.db $3F, $A7
 	.db $36, $80
 	.db $16, $A3

--- a/src/levels/7/7-2/7-2-area5.asm
+++ b/src/levels/7/7-2/7-2-area5.asm
@@ -1,7 +1,8 @@
 ; Level 7-2, Area 5
 
 LevelData_7_2_Area5:
-	.db $AA, $EA, $22, $0B
+	levelHeader 2, LevelDirection_Horizontal, 5, 2, LevelMusic_Wart, 0, 2, $0a, $1
+
 	.db $3D, $2C
 	.db $62, $48
 	.db $F0, $4F

--- a/src/levels/7/7-2/7-2-area6.asm
+++ b/src/levels/7/7-2/7-2-area6.asm
@@ -1,7 +1,8 @@
 ; Level 7-2, Area 6
 
 LevelData_7_2_Area6:
-	.db $21, $E0, $97, $01
+	levelHeader 9, LevelDirection_Vertical, 4, 1, LevelMusic_Underground, 1, 3, $00, $0
+
 	.db $08, $A5
 	.db $F5, $13, $14
 	.db $92, $4B

--- a/src/levels/7/7-2/7-2-area7.asm
+++ b/src/levels/7/7-2/7-2-area7.asm
@@ -1,7 +1,8 @@
 ; Level 7-2, Area 7
 
 LevelData_7_2_Area7:
-	.db $21, $E0, $35, $01
+	levelHeader 3, LevelDirection_Vertical, 4, 1, LevelMusic_Underground, 1, 1, $00, $0
+
 	.db $08, $A4
 	.db $F5, $13, $26
 	.db $76, $33

--- a/src/levels/7/7-2/7-2-area8.asm
+++ b/src/levels/7/7-2/7-2-area8.asm
@@ -1,7 +1,8 @@
 ; Level 7-2, Area 8
 
 LevelData_7_2_Area8:
-	.db $21, $E0, $64, $01
+	levelHeader 6, LevelDirection_Vertical, 4, 1, LevelMusic_Underground, 1, 0, $00, $0
+
 	.db $28, $A8
 	.db $2C, $0A
 	.db $F5, $13, $40

--- a/src/levels/7/7-2/7-2-area9.asm
+++ b/src/levels/7/7-2/7-2-area9.asm
@@ -1,7 +1,8 @@
 ; Level 7-2, Area 9
 
 LevelData_7_2_Area9:
-	.db $01, $FE, $30, $00
+	levelHeader 3, LevelDirection_Vertical, 0, 1, LevelMusic_Overworld, 0, 0, $1e, $0
+
 	.db $28, $10
 	.db $4D, $81
 	.db $2B, $AD

--- a/src/levels/level-data.asm
+++ b/src/levels/level-data.asm
@@ -16,14 +16,14 @@
 ;   S: sprite palette (0-3)
 ;
 ;   Byte 2: xxxGGGGG
-;   G: ground setting
+;   G: ground setting (0-31)
 ;
 ;   Byte 3: PPPPOOOO
 ;   P: number of pages minus 1 (0 = 1 page, 1 = 2 pages, etc.)
 ;   O: object type (xxOO for 3X-9X, OOxx for AX-FX)
 ;
 ;   Byte 4: xxTTTxMM
-;   T: ground type
+;   T: ground type (0-7)
 ;   M: music (0 = overworld, 1 = underground, 2 = boss, 3 = Wart)
 ;
 ; Regular object (2 bytes):

--- a/src/macros.asm
+++ b/src/macros.asm
@@ -27,6 +27,24 @@ MACRO enemy x, y, type
 	.db type, x << 4 | y
 ENDM
 
+;
+; LevelHeader macro
+;
+; The order of the parameters is slightly different than how it's encoded, but
+; hopefully this order is a little more intuitive?
+;
+MACRO levelHeader pages, horizontal, bgPalette, spritePalette, music, objectTypeAXFX, objectType3X9X, groundSetting, groundType
+	.db horizontal << 7 | bgPalette << 3 | spritePalette
+	.db %11100000 | groundSetting
+	.db pages << 4 | objectTypeAXFX << 2 | objectType3X9X
+	IFNDEF LEVEL_ENGINE_UPGRADES
+		.db groundType << 3 | music
+	ENDIF
+	IFDEF LEVEL_ENGINE_UPGRADES
+		.db groundType << 4 | music
+	ENDIF
+ENDM
+
 MACRO musicPart label
 	.db (label - MusicPartPointers)
 ENDM

--- a/src/prg-2-3.asm
+++ b/src/prg-2-3.asm
@@ -5423,77 +5423,77 @@ EnemyTilemap1:
 ; $FF is used to make an enemy invisible
 ;
 EnemyAnimationTable:
-	.db $00 ; $00
-	.db $00 ; $01
-	.db $08 ; $02
-	.db $00 ; $03
-	.db $0C ; $04
-	.db $10 ; $05
-	.db $10 ; $06
-	.db $10 ; $07
-	.db $40 ; $08
-	.db $14 ; $09
-	.db $18 ; $0A
-	.db $18 ; $0B
-	.db $18 ; $0C
-	.db $20 ; $0D
-	.db $20 ; $0E
-	.db $24 ; $0F
-	.db $24 ; $10
-	.db $BE ; $11
-	.db $00 ; $12
-	.db $86 ; $13
-	.db $88 ; $14
-	.db $FF ; $15
-	.db $FF ; $16
-	.db $8C ; $17
-	.db $5C ; $18
-	.db $5C ; $19
-	.db $6C ; $1A
-	.db $56 ; $1B
-	.db $5A ; $1C
-	.db $14 ; $1D
-	.db $72 ; $1E
-	.db $00 ; $1F
-	.db $A8 ; $20
-	.db $00 ; $21
-	.db $D6 ; $22
-	.db $AC ; $23
-	.db $AC ; $24
-	.db $AC ; $25
-	.db $74 ; $26
-	.db $7A ; $27
-	.db $92 ; $28
-	.db $9A ; $29
-	.db $80 ; $2A
-	.db $90 ; $2B
-	.db $00 ; $2C
-	.db $00 ; $2D
-	.db $B6 ; $2E
-	.db $B6 ; $2F
-	.db $B6 ; $30
-	.db $B6 ; $31
-	.db $28 ; $32
-	.db $2A ; $33
-	.db $2C ; $34
-	.db $2E ; $35
-	.db $30 ; $36
-	.db $34 ; $37
-	.db $00 ; $38
-	.db $38 ; $39
-	.db $3A ; $3A
-	.db $42 ; $3B
-	.db $82 ; $3C
-	.db $82 ; $3D
-	.db $84 ; $3E
-	.db $A0 ; $3F
-	.db $A2 ; $40
-	.db $04 ; $41
-	.db $8E ; $42
-	.db $8E ; $43
-	.db $9E ; $44
-	.db $A6 ; $45
-	.db $A4 ; $46
+	.db $00 ; $00 Enemy_Heart
+	.db $00 ; $01 Enemy_ShyguyRed
+	.db $08 ; $02 Enemy_Tweeter
+	.db $00 ; $03 Enemy_ShyguyPink
+	.db $0C ; $04 Enemy_Porcupo
+	.db $10 ; $05 Enemy_SnifitRed
+	.db $10 ; $06 Enemy_SnifitGray
+	.db $10 ; $07 Enemy_SnifitPink
+	.db $40 ; $08 Enemy_Ostro
+	.db $14 ; $09 Enemy_BobOmb
+	.db $18 ; $0A Enemy_AlbatossCarryingBobOmb
+	.db $18 ; $0B Enemy_AlbatossStartRight
+	.db $18 ; $0C Enemy_AlbatossStartLeft
+	.db $20 ; $0D Enemy_NinjiRunning
+	.db $20 ; $0E Enemy_NinjiJumping
+	.db $24 ; $0F Enemy_BeezoDiving
+	.db $24 ; $10 Enemy_BeezoStraight
+	.db $BE ; $11 Enemy_WartBubble
+	.db $00 ; $12 Enemy_Pidgit
+	.db $86 ; $13 Enemy_Trouter
+	.db $88 ; $14 Enemy_Hoopstar
+	.db $FF ; $15 Enemy_JarGeneratorShyguy
+	.db $FF ; $16 Enemy_JarGeneratorBobOmb
+	.db $8C ; $17 Enemy_Phanto
+	.db $5C ; $18 Enemy_CobratJar
+	.db $5C ; $19 Enemy_CobratSand
+	.db $6C ; $1A Enemy_Pokey
+	.db $56 ; $1B Enemy_Bullet
+	.db $5A ; $1C Enemy_Birdo
+	.db $14 ; $1D Enemy_Mouser
+	.db $72 ; $1E Enemy_Egg
+	.db $00 ; $1F Enemy_Tryclyde
+	.db $A8 ; $20 Enemy_Fireball
+	.db $00 ; $21 Enemy_Clawgrip
+	.db $D6 ; $22 Enemy_ClawgripRock
+	.db $AC ; $23 Enemy_PanserStationaryFiresAngled
+	.db $AC ; $24 Enemy_PanserWalking
+	.db $AC ; $25 Enemy_PanserStationaryFiresUp
+	.db $74 ; $26 Enemy_Autobomb
+	.db $7A ; $27 Enemy_AutobombFire
+	.db $92 ; $28 Enemy_WhaleSpout
+	.db $9A ; $29 Enemy_Flurry
+	.db $80 ; $2A Enemy_Fryguy
+	.db $90 ; $2B Enemy_FryguySplit
+	.db $00 ; $2C Enemy_Wart
+	.db $00 ; $2D Enemy_HawkmouthBoss
+	.db $B6 ; $2E Enemy_Spark1
+	.db $B6 ; $2F Enemy_Spark2
+	.db $B6 ; $30 Enemy_Spark3
+	.db $B6 ; $31 Enemy_Spark4
+	.db $28 ; $32 Enemy_VegetableSmall
+	.db $2A ; $33 Enemy_VegetableLarge
+	.db $2C ; $34 Enemy_VegetableWart
+	.db $2E ; $35 Enemy_Shell
+	.db $30 ; $36 Enemy_Coin
+	.db $34 ; $37 Enemy_Bomb
+	.db $00 ; $38 Enemy_Rocket
+	.db $38 ; $39 Enemy_MushroomBlock
+	.db $3A ; $3A Enemy_POWBlock
+	.db $42 ; $3B Enemy_FallingLogs
+	.db $82 ; $3C Enemy_SubspaceDoor
+	.db $82 ; $3D Enemy_Key
+	.db $84 ; $3E Enemy_SubspacePotion
+	.db $A0 ; $3F Enemy_Mushroom
+	.db $A2 ; $40 Enemy_Mushroom1up
+	.db $04 ; $41 Enemy_FlyingCarpet
+	.db $8E ; $42 Enemy_HawkmouthRight
+	.db $8E ; $43 Enemy_HawkmouthLeft
+	.db $9E ; $44 Enemy_CrystalBall
+	.db $A6 ; $45 Enemy_Starman
+	.db $A4 ; $46 Enemy_Stopwatch
 
 ; =============== S U B R O U T I N E =======================================
 
@@ -7125,16 +7125,16 @@ loc_BANK3_A478:
 ; ---------------------------------------------------------------------------
 byte_BANK3_A47B:
 	.db $02
-
 	.db $02
 	.db $01
 	.db $01
-byte_BANK3_A47F:
+
+FlyingCarpetTilemapIndex:
+	.db $04
+	.db $0C
+	.db $0C
 	.db $04
 
-	.db $0C
-	.db $0C
-	.db $04
 unk_BANK3_A483:
 	.db $01
 	.db $FF
@@ -7279,14 +7279,14 @@ ENDIF
 	STA ObjectXLo, X
 	LDA SpriteTempScreenY
 	CLC
-	ADC #$C
+	ADC #$0C
 	STA SpriteTempScreenY
 	LDA SpriteTempScreenX
 	SBC #$07
 	STA SpriteTempScreenX
 	JSR sub_BANK3_A552
 
-	LDA #$D
+	LDA #ObjAttrib_Palette1 | ObjAttrib_Horizontal | ObjAttrib_FrontFacing
 	STA ObjectAttributes, X
 
 locret_BANK3_A551:
@@ -7310,7 +7310,7 @@ loc_BANK3_A55F:
 	TAY
 	LDA byte_BANK3_A47B, Y
 	STA EnemyMovementDirection, X
-	LDA byte_BANK3_A47F, Y
+	LDA FlyingCarpetTilemapIndex, Y
 	JMP RenderSprite_DrawObject
 
 ; End of function sub_BANK3_A552

--- a/src/prg-2-3.asm
+++ b/src/prg-2-3.asm
@@ -5412,7 +5412,9 @@ EnemyTilemap1:
 	.db $8C,$8C ; $B4
 	.db $A6,$A6 ; $B6
 	.db $AB,$AB ; $B8
-
+IFDEF EXPAND_TABLES
+	unusedSpace EnemyTilemap1 + $100, $FB
+ENDIF
 
 ;
 ; Enemy Animation table
@@ -6430,7 +6432,10 @@ EnemyTilemap2:
 	.db $21,$23 ; $D4
 	.db $25,$27 ; $D6
 	.db $25,$27 ; $D8
-; ---------------------------------------------------------------------------
+IFDEF EXPAND_TABLES
+	unusedSpace EnemyTilemap2 + $100, $FB
+ENDIF
+
 
 EnemyInit_Clawgrip:
 	JSR EnemyInit_Birdo

--- a/src/prg-6-7.asm
+++ b/src/prg-6-7.asm
@@ -86,6 +86,9 @@ World1SpritePalettes:
 	.db $FF,$30,$16,$0F ; $18
 	.db $FF,$30,$10,$0F ; $1C
 	.db $FF,$25,$10,$0F ; $20
+IFDEF EXPAND_TABLES
+	unusedSpace World1SpritePalettes + $30, $FF
+ENDIF
 
 World2BackgroundPalettes:
 	.db $11,$30,$2A,$0F ; $00
@@ -127,6 +130,9 @@ World2SpritePalettes:
 	.db $FF,$30,$16,$0F ; $18
 	.db $FF,$30,$10,$0F ; $1C
 	.db $FF,$30,$23,$0F ; $20
+IFDEF EXPAND_TABLES
+	unusedSpace World2SpritePalettes + $30, $FF
+ENDIF
 
 World3BackgroundPalettes:
 	.db $22,$30,$12,$0F ; $00
@@ -168,6 +174,9 @@ World3SpritePalettes:
 	.db $FF,$30,$16,$0F ; $18
 	.db $FF,$30,$10,$0F ; $1C
 	.db $FF,$2B,$10,$0F ; $20
+IFDEF EXPAND_TABLES
+	unusedSpace World3SpritePalettes + $30, $FF
+ENDIF
 
 World4BackgroundPalettes:
 	.db $23,$30,$12,$0F ; $00
@@ -209,6 +218,9 @@ World4SpritePalettes:
 	.db $FF,$30,$16,$0F ; $18
 	.db $FF,$30,$10,$0F ; $1C
 	.db $FF,$27,$16,$0F ; $20
+IFDEF EXPAND_TABLES
+	unusedSpace World4SpritePalettes + $30, $FF
+ENDIF
 
 World5BackgroundPalettes:
 	.db $0F,$30,$12,$01 ; $00
@@ -250,6 +262,9 @@ World5SpritePalettes:
 	.db $FF,$30,$16,$0F ; $18
 	.db $FF,$30,$16,$0F ; $1C
 	.db $FF,$16,$30,$0F ; $20
+IFDEF EXPAND_TABLES
+	unusedSpace World5SpritePalettes + $30, $FF
+ENDIF
 
 World6BackgroundPalettes:
 	.db $21,$30,$2A,$0F ; $00
@@ -291,6 +306,9 @@ World6SpritePalettes:
 	.db $FF,$30,$16,$0F ; $18
 	.db $FF,$30,$10,$0F ; $1C
 	.db $FF,$30,$23,$0F ; $20
+IFDEF EXPAND_TABLES
+	unusedSpace World6SpritePalettes + $30, $FF
+ENDIF
 
 World7BackgroundPalettes:
 	.db $21,$30,$12,$0F ; $00
@@ -332,6 +350,9 @@ World7SpritePalettes:
 	.db $FF,$30,$16,$0F ; $18
 	.db $FF,$30,$10,$0F ; $1C
 	.db $FF,$30,$2A,$0F ; $20
+IFDEF EXPAND_TABLES
+	unusedSpace World7SpritePalettes + $30, $FF
+ENDIF
 
 GroundTilesHorizontalLo:
 	.db <World1GroundTilesHorizontal
@@ -374,7 +395,7 @@ GroundTilesVerticalHi:
 ; =======================
 ;
 ; These are the tiles used to render the ground setting of an area.
-; Each row in a world's table corresponds to the ground appearance setting.
+; Each row in a world's table corresponds to the ground type.
 ;
 ; You'll notice that the first entry, which correponds to the sky/background is
 ; $00 instead of $40. This is skipped with a BEQ in WriteGroundSetTiles,
@@ -389,6 +410,9 @@ World1GroundTilesHorizontal:
 	.db $00, $A0, $A0, $99 ; $05
 	.db $00, $00, $00, $00 ; $06
 	.db $00, $00, $00, $00 ; $07
+IFDEF EXPAND_TABLES
+	unusedSpace World1GroundTilesHorizontal + $40, $00
+ENDIF
 
 World1GroundTilesVertical:
 	.db $00, $9D, $9E, $C6 ; $00
@@ -399,6 +423,9 @@ World1GroundTilesVertical:
 	.db $00, $00, $A0, $00 ; $05
 	.db $00, $93, $9E, $C6 ; $06
 	.db $00, $40, $9E, $C6 ; $07
+IFDEF EXPAND_TABLES
+	unusedSpace World1GroundTilesVertical + $40, $00
+ENDIF
 
 World2GroundTilesHorizontal:
 	.db $00, $99, $99, $99 ; $00
@@ -409,6 +436,9 @@ World2GroundTilesHorizontal:
 	.db $00, $D6, $9B, $18 ; $05
 	.db $00, $00, $00, $00 ; $06
 	.db $00, $00, $00, $00 ; $07
+IFDEF EXPAND_TABLES
+	unusedSpace World2GroundTilesHorizontal + $40, $00
+ENDIF
 
 World2GroundTilesVertical:
 	.db $00, $9D, $9E, $C6 ; $00
@@ -419,6 +449,9 @@ World2GroundTilesVertical:
 	.db $00, $00, $00, $00 ; $05
 	.db $00, $00, $00, $00 ; $06
 	.db $00, $00, $00, $00 ; $07
+IFDEF EXPAND_TABLES
+	unusedSpace World2GroundTilesVertical + $40, $00
+ENDIF
 
 World3GroundTilesHorizontal:
 	.db $00, $99, $D5, $00 ; $00
@@ -429,6 +462,9 @@ World3GroundTilesHorizontal:
 	.db $00, $A0, $A0, $99 ; $05
 	.db $00, $00, $00, $00 ; $06
 	.db $00, $00, $00, $00 ; $07
+IFDEF EXPAND_TABLES
+	unusedSpace World3GroundTilesHorizontal + $40, $00
+ENDIF
 
 World3GroundTilesVertical:
 	.db $00, $C6, $9E, $9D ; $00
@@ -439,6 +475,9 @@ World3GroundTilesVertical:
 	.db $00, $00, $A0, $00 ; $05
 	.db $00, $40, $9E, $C6 ; $06
 	.db $00, $06, $A0, $00 ; $07
+IFDEF EXPAND_TABLES
+	unusedSpace World3GroundTilesVertical + $40, $00
+ENDIF
 
 World4GroundTilesHorizontal:
 	.db $00, $99, $D5, $00 ; $00
@@ -449,6 +488,9 @@ World4GroundTilesHorizontal:
 	.db $00, $0A, $0A, $08 ; $05
 	.db $00, $1F, $1F, $1F ; $06
 	.db $00, $00, $00, $00 ; $07
+IFDEF EXPAND_TABLES
+	unusedSpace World4GroundTilesHorizontal + $40, $00
+ENDIF
 
 World4GroundTilesVertical:
 	.db $00, $C6, $99, $9D ; $00
@@ -459,6 +501,9 @@ World4GroundTilesVertical:
 	.db $00, $18, $18, $18 ; $05
 	.db $00, $00, $00, $00 ; $06
 	.db $00, $00, $00, $00 ; $07
+IFDEF EXPAND_TABLES
+	unusedSpace World4GroundTilesVertical + $40, $00
+ENDIF
 
 World5GroundTilesHorizontal:
 	.db $00, $99, $D5, $40 ; $00
@@ -469,6 +514,9 @@ World5GroundTilesHorizontal:
 	.db $00, $A0, $A0, $99 ; $05
 	.db $00, $00, $00, $00 ; $06
 	.db $00, $00, $00, $00 ; $07
+IFDEF EXPAND_TABLES
+	unusedSpace World5GroundTilesHorizontal + $40, $00
+ENDIF
 
 World5GroundTilesVertical:
 	.db $00, $9D, $9E, $C6 ; $00
@@ -479,6 +527,9 @@ World5GroundTilesVertical:
 	.db $00, $00, $A0, $00 ; $05
 	.db $00, $93, $9E, $C6 ; $06
 	.db $00, $40, $9E, $C6 ; $07
+IFDEF EXPAND_TABLES
+	unusedSpace World5GroundTilesVertical + $40, $00
+ENDIF
 
 World6GroundTilesHorizontal:
 	.db $00, $99, $99, $99 ; $00
@@ -489,6 +540,9 @@ World6GroundTilesHorizontal:
 	.db $00, $D6, $9B, $18 ; $05
 	.db $00, $00, $00, $00 ; $06
 	.db $00, $00, $00, $00 ; $07
+IFDEF EXPAND_TABLES
+	unusedSpace World6GroundTilesHorizontal + $40, $00
+ENDIF
 
 World6GroundTilesVertical:
 	.db $00, $9D, $9E, $C6 ; $00
@@ -499,6 +553,9 @@ World6GroundTilesVertical:
 	.db $00, $00, $00, $00 ; $05
 	.db $00, $00, $00, $00 ; $06
 	.db $00, $00, $00, $00 ; $07
+IFDEF EXPAND_TABLES
+	unusedSpace World6GroundTilesVertical + $40, $00
+ENDIF
 
 World7GroundTilesHorizontal:
 	.db $00, $9C, $9C, $9C ; $00
@@ -509,6 +566,9 @@ World7GroundTilesHorizontal:
 	.db $00, $00, $00, $00 ; $05
 	.db $00, $00, $00, $00 ; $06
 	.db $00, $00, $00, $00 ; $07
+IFDEF EXPAND_TABLES
+	unusedSpace World7GroundTilesHorizontal + $40, $00
+ENDIF
 
 World7GroundTilesVertical:
 	.db $00, $9C, $9C, $9C ; $00
@@ -519,11 +579,11 @@ World7GroundTilesVertical:
 	.db $00, $00, $A0, $00 ; $05
 	.db $00, $00, $00, $00 ; $06
 	.db $00, $00, $00, $00 ; $07
+IFDEF EXPAND_TABLES
+	unusedSpace World7GroundTilesVertical + $40, $00
+ENDIF
 
-; @TODO Check this
-; Not actually sure what these are used for at all.
-; My notes say they aren't, and they don't seem to be referenced anywhere...
-; But there's so many, it would be really surprising if they are unused.
+; These seem to be unused duplicates of the tile quads from bank F
 UnusedTileQuadPointersLo:
 	.db <UnusedTileQuads1
 	.db <UnusedTileQuads2
@@ -1584,6 +1644,9 @@ SingleObjects:
 	.db BackgroundTile_SubspaceMushroom2 ; $2D
 	.db BackgroundTile_WhaleEye ; $2E
 	; No entry for $2F in this table, so it uses tile $A4 due to the LDY below
+IFDEF EXPAND_TABLES
+	.db BackgroundTile_SolidWood ; $2F
+ENDIF
 
 CreateObject_SingleObject:
 	LDY byte_RAM_E7
@@ -2501,8 +2564,10 @@ CreateObject_DrawBridgeChain_Loop:
 	RTS
 
 
+IFNDEF EXPAND_TABLES
 ; Unused space in the original ($9126 - $91FF)
 unusedSpace $9200, $FF
+ENDIF
 
 
 ;
@@ -2522,37 +2587,42 @@ unusedSpace $9200, $FF
 ;   11 - secondary background (eg. black background in 3-2)
 ;
 HorizontalGroundSetData:
-	.db $00,$00,$00,$24
-	.db $00,$00,$02,$54
-	.db $00,$02,$55,$54
-	.db $00,$02,$7F,$54
-	.db $00,$02,$7F,$D4
-	.db $00,$03,$FF,$54
-	.db $00,$02,$5F,$FC
-	.db $00,$03,$FF,$FC
-	.db $00,$00,$00,$00
-	.db $55,$55,$55,$7C
-	.db $E7,$9E,$79,$E4
-	.db $00,$0E,$79,$E4
-	.db $00,$00,$09,$E4
-	.db $00,$00,$00,$24
-	.db $E0,$0E,$79,$E4
-	.db $E4,$00,$09,$E4
-	.db $E4,$00,$00,$24
-	.db $E7,$90,$09,$E4
-	.db $E7,$9E,$70,$24
-	.db $E7,$9E,$40,$24
-	.db $E7,$9C,$00,$24
-	.db $E0,$0E,$40,$24
-	.db $00,$00,$00,$E4
-	.db $E4,$00,$00,$00
-	.db $E7,$9E,$79,$E4
-	.db $E7,$90,$01,$E4
-	.db $E0,$00,$01,$E4
-	.db $E7,$90,$00,$24
-	.db $E0,$00,$00,$24
-	.db $00,$00,$00,$24
-	.db $00,$00,$00,$24
+	.db $00,$00,$00,$24 ; $00
+	.db $00,$00,$02,$54 ; $01
+	.db $00,$02,$55,$54 ; $02
+	.db $00,$02,$7F,$54 ; $03
+	.db $00,$02,$7F,$D4 ; $04
+	.db $00,$03,$FF,$54 ; $05
+	.db $00,$02,$5F,$FC ; $06
+	.db $00,$03,$FF,$FC ; $07
+	.db $00,$00,$00,$00 ; $08
+	.db $55,$55,$55,$7C ; $09
+	.db $E7,$9E,$79,$E4 ; $0A
+	.db $00,$0E,$79,$E4 ; $0B
+	.db $00,$00,$09,$E4 ; $0C
+	.db $00,$00,$00,$24 ; $0D
+	.db $E0,$0E,$79,$E4 ; $0E
+	.db $E4,$00,$09,$E4 ; $0F
+	.db $E4,$00,$00,$24 ; $10
+	.db $E7,$90,$09,$E4 ; $11
+	.db $E7,$9E,$70,$24 ; $12
+	.db $E7,$9E,$40,$24 ; $13
+	.db $E7,$9C,$00,$24 ; $14
+	.db $E0,$0E,$40,$24 ; $15
+	.db $00,$00,$00,$E4 ; $16
+	.db $E4,$00,$00,$00 ; $17
+	.db $E7,$9E,$79,$E4 ; $18
+	.db $E7,$90,$01,$E4 ; $19
+	.db $E0,$00,$01,$E4 ; $1A
+	.db $E7,$90,$00,$24 ; $1B
+	.db $E0,$00,$00,$24 ; $1C
+	.db $00,$00,$00,$24 ; $1D
+	.db $00,$00,$00,$24 ; $1E
+	; Based on the level header parsing code, $1F seems like it may have been reserved for some
+	; special behavior at some point, but it doesn't appear to be implemented.
+IFDEF EXPAND_TABLES
+	.db $00,$00,$00,$24 ; $1F
+ENDIF
 
 ;
 ; Vertical ground set data
@@ -2569,37 +2639,42 @@ HorizontalGroundSetData:
 ;   11 - secondary background
 ;
 VerticalGroundSetData:
-	.db $AA,$AA,$AA,$AA
-	.db $80,$00,$00,$02
-	.db $AA,$00,$00,$AA
-	.db $FA,$00,$00,$AF
-	.db $FE,$00,$00,$BF
-	.db $FA,$80,$02,$AF
-	.db $E8,$00,$00,$2B
-	.db $E0,$00,$00,$0B
-	.db $FA,$95,$56,$AF
-	.db $95,$00,$00,$56
-	.db $A5,$55,$55,$5A
-	.db $A5,$5A,$A5,$5A
-	.db $55,$55,$55,$55
-	.db $95,$55,$55,$56
-	.db $95,$5A,$A5,$56
-	.db $A9,$55,$55,$6A
-	.db $81,$55,$55,$42
-	.db $AA,$A5,$55,$5A
-	.db $A5,$55,$5A,$AA
-	.db $00,$00,$00,$00
-	.db $80,$00,$00,$02
-	.db $A0,$00,$00,$0A
-	.db $AA,$00,$00,$AA
-	.db $AA,$A0,$0A,$AA
-	.db $80,$00,$0A,$AA
-	.db $80,$0A,$AA,$AA
-	.db $AA,$AA,$A0,$02
-	.db $AA,$A0,$00,$02
-	.db $A0,$0A,$A0,$0A
-	.db $A0,$00,$00,$00
-	.db $00,$00,$00,$0A
+	.db $AA,$AA,$AA,$AA ; $00
+	.db $80,$00,$00,$02 ; $01
+	.db $AA,$00,$00,$AA ; $02
+	.db $FA,$00,$00,$AF ; $03
+	.db $FE,$00,$00,$BF ; $04
+	.db $FA,$80,$02,$AF ; $05
+	.db $E8,$00,$00,$2B ; $06
+	.db $E0,$00,$00,$0B ; $07
+	.db $FA,$95,$56,$AF ; $08
+	.db $95,$00,$00,$56 ; $09
+	.db $A5,$55,$55,$5A ; $0A
+	.db $A5,$5A,$A5,$5A ; $0B
+	.db $55,$55,$55,$55 ; $0C
+	.db $95,$55,$55,$56 ; $0D
+	.db $95,$5A,$A5,$56 ; $0E
+	.db $A9,$55,$55,$6A ; $0F
+	.db $81,$55,$55,$42 ; $10
+	.db $AA,$A5,$55,$5A ; $11
+	.db $A5,$55,$5A,$AA ; $12
+	.db $00,$00,$00,$00 ; $13
+	.db $80,$00,$00,$02 ; $14
+	.db $A0,$00,$00,$0A ; $15
+	.db $AA,$00,$00,$AA ; $16
+	.db $AA,$A0,$0A,$AA ; $17
+	.db $80,$00,$0A,$AA ; $18
+	.db $80,$0A,$AA,$AA ; $19
+	.db $AA,$AA,$A0,$02 ; $1A
+	.db $AA,$A0,$00,$02 ; $1B
+	.db $A0,$0A,$A0,$0A ; $1C
+	.db $A0,$00,$00,$00 ; $1D
+	.db $00,$00,$00,$0A ; $1E
+	; Based on the level header parsing code, $1F seems like it may have been reserved for some
+	; special behavior at some point, but it doesn't appear to be implemented.
+IFDEF EXPAND_TABLES
+	.db $00,$00,$00,$0A ; $1F
+ENDIF
 
 DecodedLevelPageStartLo_Bank6:
 	.db <DecodedLevelData
@@ -3147,17 +3222,26 @@ LoadCurrentArea:
 	; ground type
 	LDY #$03
 	LDA (byte_RAM_5), Y
+IFNDEF LEVEL_ENGINE_UPGRADES
 	LSR A
 	AND #%00011100
+ENDIF
+IFDEF LEVEL_ENGINE_UPGRADES
+	; double available ground types
+	AND #%11110000
+	LSR A
+	LSR A
+ENDIF
+
+	; store ground type
 	STA GroundType
 	JSR RestoreLevelDataCopyAddress
 
 IFDEF ENABLE_LEVEL_OBJECT_MODE
 	; level object mode
 	LDA (byte_RAM_5), Y
-	ROL A
-	ROL A
-	ROL A
+	LSR A
+	LSR A
 	AND #%00000011
 	STA LevelObjectMode
 ENDIF
@@ -3209,14 +3293,14 @@ LoadCurrentArea_IsValid:
 	STA CurrentWorldTileset
 ENDIF
 
-	; ground type
+	; ground setting
 	LDA (byte_RAM_5), Y
 	AND #%00011111
-	; ground type of $1F would skip the next part, but no areas do this...?
+	; ground setting of $1F would skip the next part, but no areas do this...?
 	CMP #%00011111
 	BEQ LoadCurrentArea_StartLevelData
 
-	; store ground type
+	; store ground setting
 	STA GroundSetting
 
 	; read first object
@@ -3430,7 +3514,7 @@ ProcessSpecialObjectB:
 	.dw loc_BANK6_96BB ; Skip forward 2 pages
 	.dw loc_BANK6_9712 ; New object layer
 	.dw SetAreaPointerNoOp ; Area pointer
-	.dw loc_BANK6_971B ; Ground appearance
+	.dw SetGroundType ; Ground appearance
 IFDEF LEVEL_ENGINE_UPGRADES
 	.dw CreateRawTilesNoOp
 ENDIF
@@ -3598,7 +3682,7 @@ ReadGroundSettingOffset:
 	LDY byte_RAM_F
 	INY
 	LDA (byte_RAM_5), Y
-	AND #$E0
+	AND #%11100000
 	LSR A
 	LSR A
 	LSR A
@@ -3651,11 +3735,11 @@ SetAreaPointerNoOp:
 	RTS
 
 
-loc_BANK6_971B:
+SetGroundType:
 	LDY byte_RAM_F
 	INY
 	LDA (byte_RAM_5), Y
-	AND #$F
+	AND #%00001111
 	ASL A
 	ASL A
 	STA GroundType

--- a/src/prg-e-f.asm
+++ b/src/prg-e-f.asm
@@ -4530,6 +4530,9 @@ TileQuads1:
 	.db $32,$34,$33,$35 ; $80
 	.db $33,$35,$33,$35 ; $84
 	.db $24,$26,$25,$27 ; $88
+IFDEF EXPAND_TABLES
+	unusedSpace TileQuads1 + $100, $FC
+ENDIF
 
 TileQuads2:
 	.db $FA,$FA,$FA,$FA ; $00
@@ -4591,6 +4594,9 @@ TileQuads2:
 	.db $6C,$54,$6D,$55 ; $E0
 	.db $32,$34,$33,$35 ; $E4
 	.db $33,$35,$33,$35 ; $E8
+IFDEF EXPAND_TABLES
+	unusedSpace TileQuads2 + $100, $FC
+ENDIF
 
 TileQuads3:
 	.db $94,$95,$94,$95 ; $00
@@ -4637,7 +4643,9 @@ TileQuads3:
 	.db $72,$73,$4A,$4B ; $A4
 	.db $40,$42,$41,$43 ; $A8
 	.db $41,$43,$41,$43 ; $AC
-
+IFDEF EXPAND_TABLES
+	unusedSpace TileQuads3 + $100, $FC
+ENDIF
 TileQuads4:
 	.db $40,$42,$41,$43 ; $00
 	.db $40,$42,$41,$43 ; $04
@@ -4664,6 +4672,9 @@ TileQuads4:
 	.db $8E,$8F,$8F,$8E ; $58
 	.db $72,$73,$73,$72 ; $5C
 	.db $44,$45,$45,$44 ; $60
+IFDEF EXPAND_TABLES
+	unusedSpace TileQuads4 + $100, $FC
+ENDIF
 
 EndOfLevelDoor: ; PPU data
 	.db $22,$D0,$04,$FC,$FC,$AD,$FA

--- a/src/prg-e-f.asm
+++ b/src/prg-e-f.asm
@@ -3217,80 +3217,97 @@ loc_BANKF_F2D2:
 
 ; End of function sub_BANKF_F2C2
 
-; ---------------------------------------------------------------------------
-byte_BANKF_F2D5:
-	.db $00
-	.db $00
-	.db $00
-	.db $00
-	.db $FB
-	.db $FB
-	.db $00
-	.db $FB
-	.db $FB
-	.db $00
-	.db $FB
 
+; Tiles to use for eye sprite. If $00, this will use the character-specific table
+CharacterFrameEyeTiles:
+	.db $00 ; Walk1
+	.db $00 ; Carry1
+	.db $00 ; Walk2
+	.db $00 ; Carry2
+	.db $FB ; Duck
+	.db $FB ; DuckCarry
+	.db $00 ; Jump
+	.db $FB ; Death
+	.db $FB ; Lift
+	.db $00 ; Throw
+	.db $FB ; Climb
+
+; Specific to each character
 CharacterEyeTiles:
-	.db $D5
-	.db $D9
-	.db $FB
-	.db $D7
+	.db $D5 ; Mario
+	.db $D9 ; Luigi
+	.db $FB ; Toad
+	.db $D7 ; Princess
 
-byte_BANKF_F2E4:
-	.db $00
-
-byte_BANKF_F2E5:
-	.db $02
-
-byte_BANKF_F2E6:
-	.db $04
-
-byte_BANKF_F2E7:
-	.db $06
-	.db $0C
-	.db $0E
-	.db $10
-	.db $12
+CharacterTiles_Walk1:
 	.db $00
 	.db $02
-	.db $08
-	.db $0A
-	.db $0C
-	.db $0E
-	.db $14
-	.db $16
-	.db $FB
-	.db $FB
-	.db $2C
-	.db $2C
-	.db $FB
-	.db $FB
-	.db $2E
-	.db $2E
-	.db $0C
-	.db $0E
-	.db $10
-	.db $12
-	.db $30
-	.db $30
-	.db $32
-	.db $32
-	.db $20
-	.db $22
-	.db $24
-	.db $26
-	.db $00
-	.db $02
-	.db $28
-	.db $2A
-	.db $18
-	.db $1A
-	.db $1C
-	.db $1E
-; Princess jump frames
-	.db $B4
-	.db $B6
+	.db $04 ; $00 - start of relative character tile offets, for some reason
+	.db $06 ; $01
+
+CharacterTiles_Carry1:
+	.db $0C ; $02
+	.db $0E ; $03
+	.db $10 ; $04
+	.db $12 ; $05
+
+CharacterTiles_Walk2:
+	.db $00 ; $06
+	.db $02 ; $07
+	.db $08 ; $08
+	.db $0A ; $09
+
+CharacterTiles_Carry2:
+	.db $0C ; $0a
+	.db $0E ; $0b
+	.db $14 ; $0c
+	.db $16 ; $0d
+
+CharacterTiles_Duck:
+	.db $FB ; $0e
+	.db $FB ; $0f
+	.db $2C ; $10
+	.db $2C ; $11
+
+CharacterTiles_DuckCarry:
+	.db $FB ; $12
+	.db $FB ; $13
+	.db $2E ; $14
+	.db $2E ; $15
+
+CharacterTiles_Jump:
+	.db $0C ; $16
+	.db $0E ; $17
+	.db $10 ; $18
+	.db $12 ; $19
+
+CharacterTiles_Death:
+	.db $30 ; $1a
+	.db $30 ; $1b
+	.db $32 ; $1c
+	.db $32 ; $1d
+
+CharacterTiles_Lift:
+	.db $20 ; $1e
+	.db $22 ; $1f
+	.db $24 ; $20
+	.db $26 ; $21
+
+CharacterTiles_Throw:
+	.db $00 ; $22
+	.db $02 ; $23
+	.db $28 ; $24
+	.db $2A ; $25
+
+CharacterTiles_Climb:
+	.db $18 ; $26
+	.db $1A ; $27
+	.db $1C ; $28
+	.db $1E ; $29
+
+CharacterTiles_PrincessJumpBody:
+	.db $B4 ; $2a
+	.db $B6 ; $2b
 
 DamageInvulnBlinkFrames:
 	.db $01, $01, $01, $02, $02, $04, $04, $04
@@ -3516,7 +3533,7 @@ loc_BANKF_F3EE:
 loc_BANKF_F3F8:
 	STA SpriteDMAArea + $26
 	STA SpriteDMAArea + $2E
-	LDA byte_BANKF_F2D5, X
+	LDA CharacterFrameEyeTiles, X
 	BNE loc_BANKF_F408
 
 	LDX CurrentCharacter
@@ -3539,9 +3556,9 @@ loc_BANKF_F413:
 
 	LDA SpriteDMAArea + $23
 	STA SpriteDMAArea + 3, Y
-	LDA byte_BANKF_F2E4, X
+	LDA CharacterTiles_Walk1, X
 	STA SpriteDMAArea + $21
-	LDA byte_BANKF_F2E5, X
+	LDA CharacterTiles_Walk1 + 1, X
 	STA SpriteDMAArea + $25
 	LDA PlayerCurrentSize
 	BNE loc_BANKF_F43F
@@ -3557,17 +3574,17 @@ loc_BANKF_F413:
 	LDX #$2A
 
 loc_BANKF_F43F:
-	LDA byte_BANKF_F2E6, X
+	LDA CharacterTiles_Walk1 + 2, X
 	STA SpriteDMAArea + $29
-	LDA byte_BANKF_F2E7, X
+	LDA CharacterTiles_Walk1 + 3, X
 	BNE loc_BANKF_F478
 
 loc_BANKF_F44A:
 	LDA SpriteDMAArea + $27
 	STA SpriteDMAArea + 3, Y
-	LDA byte_BANKF_F2E5, X
+	LDA CharacterTiles_Walk1 + 1, X
 	STA SpriteDMAArea + $21
-	LDA byte_BANKF_F2E4, X
+	LDA CharacterTiles_Walk1, X
 	STA SpriteDMAArea + $25
 	LDA PlayerCurrentSize
 	BNE loc_BANKF_F46F
@@ -3583,9 +3600,9 @@ loc_BANKF_F44A:
 	LDX #$2A
 
 loc_BANKF_F46F:
-	LDA byte_BANKF_F2E7, X
+	LDA CharacterTiles_Walk1 + 3, X
 	STA SpriteDMAArea + $29
-	LDA byte_BANKF_F2E6, X
+	LDA CharacterTiles_Walk1 + 2, X
 
 loc_BANKF_F478:
 	STA SpriteDMAArea + $2D

--- a/src/prg-e-f.asm
+++ b/src/prg-e-f.asm
@@ -3288,6 +3288,7 @@ byte_BANKF_F2E7:
 	.db $1A
 	.db $1C
 	.db $1E
+; Princess jump frames
 	.db $B4
 	.db $B6
 


### PR DESCRIPTION
* Added `EXPAND_TABLES` config flag, which pads a few tables if they're built to support more values than they actually use in vanilla SMB2 (there are probably more than can use this, particularly the enemy tables)
* Annotated some tile data (mostly the player character)
* Annotated some Pidgit/Flying carpet stuff