### PR TITLE
Add note bend support for pulse channels

### DIFF
--- a/src/prg-2-3.asm
+++ b/src/prg-2-3.asm
@@ -5296,6 +5296,9 @@ EnemyBehavior_CheckDamagedInterrupt_SoundEffect:
 	BNE EnemyBehavior_CheckDamagedInterrupt_CheckPidgit
 
 EnemyBehavior_CheckDamagedInterrupt_BossDeathSound:
+IFDEF EXPAND_MUSIC
+	LDA #DPCM_BossDeath
+ENDIF
 	STA DPCMQueue
 
 EnemyBehavior_CheckDamagedInterrupt_CheckPidgit:

--- a/src/ram.asm
+++ b/src/ram.asm
@@ -1512,7 +1512,7 @@ CurrentMusicNoiseStartOffset:
 	.dsb 1 ; $05f6
 	.dsb 1 ; $05f7
 	.dsb 1 ; $05f8
-UNUSED_MusicSquare1Lo:
+MusicSquare1Lo:
 	.dsb 1 ; $05f9
 MusicDPCMNoteLength:
 	.dsb 1 ; $05fa
@@ -1520,7 +1520,7 @@ MusicDPCMNoteStartLength:
 	.dsb 1 ; $05fb
 CurrentMusicDPCMStartOffset:
 	.dsb 1 ; $05fc
-UNUSED_MusicSquare2Lo:
+MusicSquare2Lo:
 	.dsb 1 ; $05fd
 	.dsb 1 ; $05fe
 CurrentMusicDPCMOffset:
@@ -1603,6 +1603,7 @@ MusicPlaying1:
 DPCMTimer:
 	.dsb 1 ; $060a
 ; FOR RENT
+MusicSquare1NoteBend:
 	.dsb 1 ; $060b
 MusicSquare1NoteSweep:
 	.dsb 1 ; $060c
@@ -1610,8 +1611,9 @@ SoundEffectPlaying2:
 	.dsb 1 ; $060d
 SoundEffectPlaying3:
 	.dsb 1 ; $060e
-; FOR RENT
+MusicSquare2NoteBend:
 	.dsb 1 ; $060f
+; FOR RENT
 	.dsb 1 ; $0610
 SoundEffectTimer3:
 	.dsb 1 ; $0611

--- a/src/ram.asm
+++ b/src/ram.asm
@@ -1521,7 +1521,7 @@ MusicDPCMNoteStartLength:
 CurrentMusicDPCMStartOffset:
 	.dsb 1 ; $05fc
 MusicSquare2Lo:
-	.dsb 1 ; $05fd
+	.dsb 1 ; $05fd  (unused; written to but not read)
 	.dsb 1 ; $05fe
 CurrentMusicDPCMOffset:
 	.dsb 1 ; $05ff

--- a/src/ram.asm
+++ b/src/ram.asm
@@ -1513,7 +1513,7 @@ CurrentMusicNoiseStartOffset:
 	.dsb 1 ; $05f7
 	.dsb 1 ; $05f8
 MusicSquare1Lo:
-	.dsb 1 ; $05f9
+	.dsb 1 ; $05f9 (unused; written to but not read)
 MusicDPCMNoteLength:
 	.dsb 1 ; $05fa
 MusicDPCMNoteStartLength:


### PR DESCRIPTION
Minor: This has a fix for the boss death sound, which was broken with the `EXPAND_MUSIC` flag due to some overloaded bit flag logic.

The meat of this is the note bend code, which is ripped more or less directly from SMB3. Basically two notes joined by `$FF` will bend from the first note to the second one. Interestingly, some RAM locations that are written to but not read in vanilla SMB2 get used by the pitch bend code. It makes me wonder whether there was some larger plan for the general Mario music engine and this just represents the transitional state it was in before SMB3.

I'm curious about what Doki Doki Panic looks like in comparison, but (based on no evidence whatsoever) I kind of suspect that it's using a completely different music engine in the first place.