### PR TITLE
More robust vine transitions, tweaks to uninitialized music RAM

### DIFF
--- a/src/prg-4-5.asm
+++ b/src/prg-4-5.asm
@@ -713,12 +713,13 @@ ProcessMusicQueue_Square2Note:
 	TAY
 	BNE ProcessMusicQueue_Square2StartNote
 
-	LDA UNINITIALIZED_MusicSquare2Volume
+	LDA MusicSquareInstrumentStartOffset
 	JMP ProcessMusicQueue_Square2UpdateNoteOffset
 
 ProcessMusicQueue_Square2StartNote:
 	LDA MusicSquare2NoteStartLength
-	LDX UNINITIALIZED_MusicSquare2Volume ; always overridden in the following subroutine...?
+	; seems like the next line should be LDX MusicSquareEnvelope based on the equivalent code for square 1?
+	LDX MusicSquareInstrumentStartOffset ; always overridden in the following subroutine...?
 	JSR SetInstrumentStartOffset
 
 ProcessMusicQueue_Square2UpdateNoteOffset:
@@ -804,12 +805,12 @@ ProcessMusicQueue_Square1Note:
 
 	BNE ProcessMusicQueue_Square1StartNote
 
-	LDA UNINITIALIZED_MusicSquare2Volume
+	LDA MusicSquareInstrumentStartOffset
 	JMP ProcessMusicQueue_Square1UpdateNoteOffset
 
 ProcessMusicQueue_Square1StartNote:
 	LDA MusicSquare1NoteStartLength
-	LDX UNINITIALIZED_MusicSquare1Volume ; always overridden in the following subroutine...?
+	LDX MusicSquareEnvelope ; always overridden in the following subroutine...?
 	JSR SetInstrumentStartOffset
 
 ProcessMusicQueue_Square1UpdateNoteOffset:
@@ -1314,7 +1315,7 @@ PlayNote_SetFrequency_Square2Detuned:
 	SEC
 	SBC #$02
 	STA SQ2_LO
-	STA UNINITIALIZED_MusicSquare2Lo ; unused
+	STA MusicSquare2Lo
 	LDA NextFrequencyHi
 	ORA #$08
 	STA SQ2_HI

--- a/src/ram.asm
+++ b/src/ram.asm
@@ -336,13 +336,15 @@ NextFrequencyHi:
 ; Seems like they were intended to be either instrument start offets or
 ; duty/volume/envelope for the square channels, but it's not totally clear
 ; from the code, and doesn't actually function as written?
-UNINITIALIZED_MusicSquare2Volume: ; ???
+MusicSquareInstrumentStartOffset: ; (unused; read but never initialized)
 	.dsb 1 ; $00bf
-UNINITIALIZED_MusicSquare1Volume: ; ???
+MusicSquareEnvelope: ; (unused; always overwritten)
 	.dsb 1 ; $00c0
 SoundEffect1DataOffset:
 	.dsb 1 ; $00c1
-UNINITIALIZED_MusicSquare2Lo: ; ???
+IFNDEF EXPAND_MUSIC
+MusicSquare2Lo: ; (unused)
+ENDIF
 	.dsb 1 ; $00c2
 	.dsb 1 ; $00c3
 SoundEffectTimer2:
@@ -1520,8 +1522,10 @@ MusicDPCMNoteStartLength:
 	.dsb 1 ; $05fb
 CurrentMusicDPCMStartOffset:
 	.dsb 1 ; $05fc
-MusicSquare2Lo:
-	.dsb 1 ; $05fd  (unused; written to but not read)
+IFDEF EXPAND_MUSIC
+MusicSquare2Lo: ; needs to be +$04 relative to MusicSquare1Lo
+ENDIF
+	.dsb 1 ; $05fd (unused; written to but not read)
 	.dsb 1 ; $05fe
 CurrentMusicDPCMOffset:
 	.dsb 1 ; $05ff


### PR DESCRIPTION
* Adds a second pass to the robust vine search so that climbable tiles on the "wrong" side of the screen are used when the "right" side of the screen doesn't have an appropriate climbable tile
* Removed `UNINITIALIZED_` prefix from some RAM labels and added relevant notes. `EXPAND_MUSIC` now changes the location of `MusicSquare2Lo` to maintain a +4 offset from `MusicSquare1Lo` when it's being used for pitch bend