### PR TITLE
Compat update

### DIFF
--- a/src/compatibility-shims.asm
+++ b/src/compatibility-shims.asm
@@ -1,0 +1,60 @@
+;
+; Macros for compatibility reasons
+; ================================
+;
+; asm6f doesn't have a way of specifying "aboslute mode" by force,
+; and some areas of SMB2 use it even in cases where a zero-page instruction
+; would have been sufficient, so these are here to allow those to exist
+; (by emitting the raw bytes) if needed
+;
+
+
+;
+; Emit a NOP if PRESERVE_UNUSED_SPACE is on,
+; as non-compat opcodes are one byte smaller
+; (will keep data in place if using proper ZP opcodes)
+;
+MACRO NOP_compat
+	IFDEF PRESERVE_UNUSED_SPACE
+		NOP
+	ENDIF
+ENDM
+
+;
+; LDA $0000
+;
+MACRO LDA_abs addr
+	IFDEF COMPATIBILITY
+		.db $ad
+		.dw addr
+	ELSE
+		LDA addr
+		NOP_compat
+	ENDIF
+ENDM
+
+;
+; STA $0000
+;
+MACRO STA_abs addr
+	IFDEF COMPATIBILITY
+		.db $8d
+		.dw addr
+	ELSE
+		STA addr
+		NOP_compat
+	ENDIF
+ENDM
+
+;
+; INC $0000
+;
+MACRO INC_abs addr
+	IFDEF COMPATIBILITY
+		.db $ee
+		.dw addr
+	ELSE
+		INC addr
+		NOP_compat
+	ENDIF
+ENDM

--- a/src/compatibility-shims.asm
+++ b/src/compatibility-shims.asm
@@ -60,6 +60,19 @@ MACRO LDX_abs addr
 ENDM
 
 ;
+; LDY $0000
+;
+MACRO LDY_abs addr
+	IFDEF COMPATIBILITY
+		.db $ac
+		.dw addr
+	ELSE
+		LDX addr
+		NOP_compat
+	ENDIF
+ENDM
+
+;
 ; STA $0000
 ;
 MACRO STA_abs addr

--- a/src/compatibility-shims.asm
+++ b/src/compatibility-shims.asm
@@ -34,6 +34,32 @@ MACRO LDA_abs addr
 ENDM
 
 ;
+; LDA $0000, X
+;
+MACRO LDA_abs_X addr
+	IFDEF COMPATIBILITY
+		.db $bd
+		.dw addr
+	ELSE
+		LDA addr, X
+		NOP_compat
+	ENDIF
+ENDM
+
+;
+; LDX $0000
+;
+MACRO LDX_abs addr
+	IFDEF COMPATIBILITY
+		.db $ae
+		.dw addr
+	ELSE
+		LDX addr
+		NOP_compat
+	ENDIF
+ENDM
+
+;
 ; STA $0000
 ;
 MACRO STA_abs addr
@@ -47,11 +73,37 @@ MACRO STA_abs addr
 ENDM
 
 ;
+; STY $0000
+;
+MACRO STY_abs addr
+	IFDEF COMPATIBILITY
+		.db $8c
+		.dw addr
+	ELSE
+		STY addr
+		NOP_compat
+	ENDIF
+ENDM
+
+;
 ; INC $0000
 ;
 MACRO INC_abs addr
 	IFDEF COMPATIBILITY
 		.db $ee
+		.dw addr
+	ELSE
+		INC addr
+		NOP_compat
+	ENDIF
+ENDM
+
+;
+; AND $0000
+;
+MACRO AND_abs addr
+	IFDEF COMPATIBILITY
+		.db $2d
 		.dw addr
 	ELSE
 		INC addr

--- a/src/macros.asm
+++ b/src/macros.asm
@@ -4,6 +4,8 @@
 ;
 ;
 
+; Include COMPATIBILITY-flag-related macros
+include "src/compatibility-shims.asm"
 
 ;
 ; Pad out unused space used in the original, if needed

--- a/src/prg-0-1.asm
+++ b/src/prg-0-1.asm
@@ -2202,13 +2202,7 @@ HandlePlayerState_HawkmouthEating:
 
 	JSR ApplyPlayerPhysicsY
 
-IFDEF COMPATIBILITY
-	.db $ad, $5a, $00 ; LDA $0000 + PlayerCollision
-ENDIF
-IFNDEF COMPATIBILITY
-	LDA PlayerCollision ; Absolute address for zero-page
-	NOP ; Alignment fix
-ENDIF
+	LDA_abs PlayerCollision
 
 	BEQ locret_BANK0_8BEB
 
@@ -6403,13 +6397,7 @@ loc_BANK1_AC0A:
 	CMP #$20
 	BCC loc_BANK1_AC37
 
-IFDEF COMPATIBILITY
-	.db $ee, $e6, $00 ; INC $00E6
-ENDIF
-IFNDEF COMPATIBILITY
-	INC byte_RAM_E6 ; Absolute address for zero-page
-	NOP ; Alignment fix
-ENDIF
+	INC_abs byte_RAM_E6
 
 	LDA #$A0
 	STA byte_RAM_10
@@ -6513,13 +6501,8 @@ loc_BANK1_AC8B:
 	STA ObjectXVelocity + 6
 	LDA #$0DA
 	STA ObjectYVelocity + 6
-IFDEF COMPATIBILITY
-	.db $ee, $e6, $00 ; INC $00E6
-ENDIF
-IFNDEF COMPATIBILITY
-	INC byte_RAM_E6 ; Absolute address for zero-page
-	NOP ; Alignment fix
-ENDIF
+
+	INC_abs byte_RAM_E6
 
 
 loc_BANK1_ACA4:
@@ -6777,13 +6760,8 @@ ContributorTicker:
 	LDA Contributors, Y
 	CLC
 	ADC #$09
-IFDEF COMPATIBILITY
-	.db $8d, $11, $00 ; STA $0011
-ENDIF
-IFNDEF COMPATIBILITY
-	STA ScreenUpdateIndex ; Absolute address for zero-page
-	NOP ; Alignment fix
-ENDIF
+
+	STA_abs ScreenUpdateIndex
 
 	DEC ContributorIndex
 	BPL ContributorTicker_Exit

--- a/src/prg-2-3.asm
+++ b/src/prg-2-3.asm
@@ -6607,13 +6607,7 @@ byte_BANK3_A1DC:
 
 
 RenderSprite_Clawgrip:
-IFDEF COMPATIBILITY
-	.db $ad, $f4, $00 ; LDA $00F4
-ENDIF
-IFNDEF COMPATIBILITY
-	LDA byte_RAM_F4 ; Absolute address for zero-page
-	NOP ; Alignment fix
-ENDIF
+	LDA_abs byte_RAM_F4
 
 	STA EnemyArray_B1, X
 	LDY EnemyState, X
@@ -6754,13 +6748,7 @@ loc_BANK3_A2AA:
 	JSR sub_BANK2_8894
 
 	LDY #$00
-IFDEF COMPATIBILITY
-	.db $8c, $f4, $00 ; STY $00F4
-ENDIF
-IFNDEF COMPATIBILITY
-	STY byte_RAM_F4 ; Absolute address for zero-page
-	NOP ; Alignment fix
-ENDIF
+	STY_abs byte_RAM_F4
 
 	LDA ObjectAttributes, X
 	PHA
@@ -6790,13 +6778,7 @@ loc_BANK3_A2D2:
 	AND #$04
 	BEQ loc_BANK3_A2E1
 
-IFDEF COMPATIBILITY
-	.db $ae, $f4, $00 ; LDX $00F4
-ENDIF
-IFNDEF COMPATIBILITY
-	LDX byte_RAM_F4 ; Absolute address for zero-page
-	NOP ; Alignment fix
-ENDIF
+	LDX_abs byte_RAM_F4
 
 	DEC SpriteDMAArea + $C, X
 	LDX byte_RAM_12
@@ -6855,13 +6837,7 @@ loc_BANK3_A320:
 ; ---------------------------------------------------------------------------
 
 RenderSprite_ClawgripRock:
-IFDEF COMPATIBILITY
-	.db $bd, $a8, $00 ; LDA $00A8, X
-ENDIF
-IFNDEF COMPATIBILITY
-	LDA ObjectBeingCarriedTimer, X ; Absolute address for zero-page
-	NOP ; Alignment fix
-ENDIF
+	LDA_abs_X ObjectBeingCarriedTimer ;, X
 
 	ORA EnemyArray_438, X
 	BNE loc_BANK3_A362
@@ -6993,13 +6969,7 @@ loc_BANK3_A3C7:
 	LDA Player1JoypadHeld
 	AND #ControllerInput_Right | ControllerInput_Left
 	TAY
-IFDEF COMPATIBILITY
-	.db $2d, $5a, $00 ; AND $0000 + PlayerCollision
-ENDIF
-IFNDEF COMPATIBILITY
-	AND PlayerCollision ; Absolute address for zero-page
-	NOP ; Alignment fix
-ENDIF
+	AND_abs PlayerCollision
 
 	BNE loc_BANK3_A3E6
 
@@ -7260,13 +7230,7 @@ RenderSprite_Pidgit:
 	; Render Pidgit's carpet
 	JSR loc_BANKF_FAFE
 
-IFDEF COMPATIBILITY
-	.db $8c, $f4, $00 ; STY $00F4
-ENDIF
-IFNDEF COMPATIBILITY
-	STY byte_RAM_F4 ; Absolute address for zero-page
-	NOP ; Alignment fix
-ENDIF
+	STY_abs byte_RAM_F4
 
 	LDA #ObjAttrib_Palette1 | ObjAttrib_Horizontal | ObjAttrib_16x32
 	STA ObjectAttributes, X
@@ -7487,14 +7451,7 @@ RenderSprite_Mouser_Bomb:
 	STA SpriteTempScreenX
 	ASL byte_RAM_EE
 	LDY #$00
-IFDEF COMPATIBILITY
-	.db $8c, $f4, $00 ; STY $00F4
-ENDIF
-IFNDEF COMPATIBILITY
-	STY byte_RAM_F4 ; Absolute address for zero-page
-	NOP ; Alignment fix
-ENDIF
-
+	STY_abs byte_RAM_F4
 	LDA #$38 ; could have been $34 from tilemap 1 instead
 	JSR RenderSprite_DrawObject
 
@@ -7775,14 +7732,7 @@ RenderSprite_Tryclyde:
 RenderSprite_Tryclyde_DrawBody:
 	TYA
 	LDY #$30
-IFDEF COMPATIBILITY
-	.db $8c, $f4, $00 ; STY $00F4
-ENDIF
-IFNDEF COMPATIBILITY
-	STY byte_RAM_F4 ; Absolute address for zero-page
-	NOP ; Alignment fix
-ENDIF
-
+	STY_abs byte_RAM_F4
 	JSR RenderSprite_DrawObject
 
 	LDA #ObjAttrib_Palette1 | ObjAttrib_FrontFacing
@@ -8473,13 +8423,7 @@ EnemyBehavior_Rocket_ApplyPhysics:
 	LDA #TransitionType_Rocket
 	STA TransitionType
 	LDA #$00
-IFDEF COMPATIBILITY
-	.db $8d, $50, $00 ; STA $0000 + PlayerState
-ENDIF
-IFNDEF COMPATIBILITY
-	STA PlayerState ; Absolute address for zero-page
-	NOP ; Alignment fix
-ENDIF
+	STA_abs PlayerState
 
 	RTS
 
@@ -8632,14 +8576,7 @@ loc_BANK3_AC4B:
 
 	JSR loc_BANKF_FAFE
 
-IFDEF COMPATIBILITY
-	.db $8c, $f4, $00 ; STY $00F4
-ENDIF
-IFNDEF COMPATIBILITY
-	STY byte_RAM_F4 ; Absolute address for zero-page
-	NOP ; Alignment fix
-ENDIF
-
+	STY_abs byte_RAM_F4
 	PLA
 	CLC
 	LDY byte_RAM_7
@@ -9030,14 +8967,7 @@ loc_BANK3_AE5C:
 	LDA EnemyArray_B1, X
 	BNE loc_BANK3_AE7C
 
-IFDEF COMPATIBILITY
-	.db $ad, $f4, $00 ; LDA $00F4
-ENDIF
-IFNDEF COMPATIBILITY
-	LDA byte_RAM_F4 ; Absolute address for zero-page
-	NOP ; Alignment fix
-ENDIF
-
+	LDA_abs byte_RAM_F4
 	PHA
 	LDA SpriteTempScreenY
 	CLC
@@ -9045,26 +8975,12 @@ ENDIF
 	STA SpriteTempScreenY
 	JSR loc_BANKF_FAFE
 
-IFDEF COMPATIBILITY
-	.db $8c, $f4, $00 ; STY $00F4
-ENDIF
-IFNDEF COMPATIBILITY
-	STY byte_RAM_F4 ; Absolute address for zero-page
-	NOP ; Alignment fix
-ENDIF
-
+	STY_abs byte_RAM_F4
 	LDA #$7C
 	JSR RenderSprite_DrawObject
 
 	PLA
-IFDEF COMPATIBILITY
-	.db $8d, $f4, $00 ; STA $00F4
-ENDIF
-IFNDEF COMPATIBILITY
-	STA byte_RAM_F4 ; Absolute address for zero-page
-	NOP ; Alignment fix
-ENDIF
-
+	STA_abs byte_RAM_F4
 
 loc_BANK3_AE7C:
 	LDA ObjectYLo, X
@@ -9076,14 +8992,7 @@ loc_BANK3_AE7C:
 	TYA
 	CLC
 	ADC #$08
-IFDEF COMPATIBILITY
-	.db $8d, $f4, $00 ; STA $00F4
-ENDIF
-IFNDEF COMPATIBILITY
-	STA byte_RAM_F4 ; Absolute address for zero-page
-	NOP ; Alignment fix
-ENDIF
-
+	STA_abs byte_RAM_F4
 	LDA byte_RAM_0
 	STA SpriteTempScreenY
 	LDA #%11010000
@@ -9213,14 +9122,7 @@ loc_BANK3_AF29:
 
 loc_BANK3_AF34:
 	STA SpriteDMAArea + $D, Y
-IFDEF COMPATIBILITY
-	.db $ae, $f4, $00 ; LDX $00F4
-ENDIF
-IFNDEF COMPATIBILITY
-	LDX byte_RAM_F4 ; Absolute address for zero-page
-	NOP ; Alignment fix
-ENDIF
-
+	LDX_abs byte_RAM_F4
 	LDA SpriteDMAArea + 2, X
 	STA SpriteDMAArea + 2, Y
 	STA SpriteDMAArea + 6, Y
@@ -9580,14 +9482,7 @@ loc_BANK3_B13B:
 	STA SpriteDMAArea + 6, Y
 	STA SpriteDMAArea + $A, Y
 	STA SpriteDMAArea + $E, Y
-IFDEF COMPATIBILITY
-	.db $ae, $f4, $00 ; LDX $00F4
-ENDIF
-IFNDEF COMPATIBILITY
-	LDX byte_RAM_F4 ; Absolute address for zero-page
-	NOP ; Alignment fix
-ENDIF
-
+	LDX_abs byte_RAM_F4
 	LDA SpriteDMAArea, X
 	STA SpriteDMAArea + 8, Y
 	CLC
@@ -9869,14 +9764,7 @@ EnemyBehavior_WartBubble_Exit:
 
 
 RenderSprite_Wart:
-IFDEF COMPATIBILITY
-	.db $ad, $f4, $00 ; LDA $00F4
-ENDIF
-IFNDEF COMPATIBILITY
-	LDA byte_RAM_F4 ; Absolute address for zero-page
-	NOP ; Alignment fix
-ENDIF
-
+	LDA_abs byte_RAM_F4
 	STA byte_RAM_7267
 	STA byte_RAM_726B
 	LDA byte_RAM_10
@@ -9884,14 +9772,7 @@ ENDIF
 	STA byte_RAM_7
 	TAY
 	LDA unk_RAM_7265, Y
-IFDEF COMPATIBILITY
-	.db $8d, $f4, $00 ; STA $00F4
-ENDIF
-IFNDEF COMPATIBILITY
-	STA byte_RAM_F4 ; Absolute address for zero-page
-	NOP ; Alignment fix
-ENDIF
-
+	STA_abs byte_RAM_F4
 	LDA byte_RAM_EF
 	BNE EnemyBehavior_WartBubble_Exit
 
@@ -9939,14 +9820,7 @@ RenderSprite_Wart_DrawTop:
 	STA SpriteTempScreenY
 	LDY byte_RAM_7
 	LDA unk_RAM_7266, Y
-IFDEF COMPATIBILITY
-	.db $8d, $f4, $00 ; STA $00F4
-ENDIF
-IFNDEF COMPATIBILITY
-	STA byte_RAM_F4 ; Absolute address for zero-page
-	NOP ; Alignment fix
-ENDIF
-
+	STA_abs byte_RAM_F4
 	LDY #$A6 ; middle row: regular
 	LDA EnemyArray_B1, X
 	BNE RenderSprite_Wart_MiddleHurt
@@ -9979,14 +9853,7 @@ RenderSprite_Wart_DrawMiddle:
 	STA SpriteTempScreenY
 	LDY byte_RAM_7
 	LDA byte_RAM_7267, Y
-IFDEF COMPATIBILITY
-	.db $8d, $f4, $00 ; STA $00F4
-ENDIF
-IFNDEF COMPATIBILITY
-	STA byte_RAM_F4 ; Absolute address for zero-page
-	NOP ; Alignment fix
-ENDIF
-
+	STA_abs byte_RAM_F4
 	LDY #$BA ; bottom row: standing
 	LDA ObjectXVelocity, X
 	BEQ RenderSprite_Wart_DrawBottom

--- a/src/prg-6-7.asm
+++ b/src/prg-6-7.asm
@@ -2652,13 +2652,7 @@ loc_BANK6_909C:
 	STA byte_RAM_E7
 	LDA #$0D
 	STA byte_RAM_50E
-IFDEF COMPATIBILITY
-	.db $ad, $07, $00 ; LDA $0007
-ENDIF
-IFNDEF COMPATIBILITY
-	LDA byte_RAM_7 ; Absolute address for zero-page
-	NOP ; Alignment fix
-ENDIF
+	LDA_abs byte_RAM_7
 
 	STA byte_RAM_50D
 	LDX byte_RAM_E8
@@ -2994,14 +2988,7 @@ ResetLevelData_Loop:
 	STA ScreenYLo
 	STA ScreenBoundaryLeftHi
 	STA ScreenBoundaryLeftLo
-IFDEF COMPATIBILITY
-	.db $8d, $d8, $00 ; STA $00D8
-ENDIF
-IFNDEF COMPATIBILITY
-	STA NeedVerticalScroll ; Absolute address for zero-page
-	NOP ; Alignment fix
-ENDIF
-
+	STA_abs NeedVerticalScroll
 	RTS
 
 

--- a/src/prg-e-f.asm
+++ b/src/prg-e-f.asm
@@ -2279,23 +2279,9 @@ NMI:
 	STA PPUCTRL
 
 loc_BANKF_EBC9:
-IFDEF COMPATIBILITY
-	.db $ad, $d1, $00 ; LDA $00D1
-ENDIF
-IFNDEF COMPATIBILITY
-	LDA byte_RAM_D1 ; Absolute address for zero-page
-	NOP ; Alignment fix
-ENDIF
-
+	LDA_abs byte_RAM_D1
 	STA PPUADDR
-IFDEF COMPATIBILITY
-	.db $ad, $d2, $00 ; LDA $00D2
-ENDIF
-IFNDEF COMPATIBILITY
-	LDA byte_RAM_D2 ; Absolute address for zero-page
-	NOP ; Alignment fix
-ENDIF
-
+	LDA_abs byte_RAM_D2
 	STA PPUADDR
 
 loc_BANKF_EBD5:
@@ -2306,13 +2292,7 @@ loc_BANKF_EBD5:
 	BNE loc_BANKF_EBD5
 
 	LDX #$1E
-IFDEF COMPATIBILITY
-	.db $ee, $d2, $00 ; INC $00D2
-ENDIF
-IFNDEF COMPATIBILITY
-	INC byte_RAM_D2 ; Absolute address for zero-page
-	NOP ; Alignment fix
-ENDIF
+	INC_abs byte_RAM_D2
 
 	CPY #$3C
 	BNE loc_BANKF_EBC9
@@ -3383,14 +3363,7 @@ IFDEF CONTROLLER_2_DEBUG
 RenderPlayer_AfterChangeCharacterPoof:
 ENDIF
 
-IFDEF COMPATIBILITY
-	.db $ac, $50, $00 ; LDA $0000 + PlayerState
-ENDIF
-IFNDEF COMPATIBILITY
-	LDY PlayerState ; Absolute address for zero-page
-	NOP ; Alignment fix
-ENDIF
-
+	LDY_abs PlayerState
 	CPY #PlayerState_ChangingSize
 	BEQ loc_BANKF_F337
 


### PR DESCRIPTION
This changes the absolute-addressing-zero-page opcodes from and `IFDEF` branch to macros that look closer to the actual instructions.


Before:
```assembly
IFDEF COMPATIBILITY
	.db $ee, $d2, $00 ; INC $00D2
ENDIF
IFNDEF COMPATIBILITY
	INC byte_RAM_D2 ; Absolute address for zero-page
	NOP ; Alignment fix
ENDIF
```

After:
```assembly
	INC_abs byte_RAM_D2
```

Macros like this are used:

```assembly
;
; LDA $0000
;
MACRO LDA_abs addr
	IFDEF COMPATIBILITY
		.db $ad
		.dw addr
	ELSE
		LDA addr
		NOP_compat ; "IFDEF PRESERVE_UNUSED_SPACE nop END" to keep alignment
	ENDIF
ENDM
```

In the one case of indexed absolute addressing modes, the macro and line are instead
```assembly
	LDA_abs_X ObjectBeingCarriedTimer ;, X
```
(because we can't do optional macro arguments; it's the best I could manage, but should make it easy to fix if asm6f gets support for forced-absolute addressing mode)

As a bonus, this removes the raw memory address references, so in the event those get shifted around it should no longer cause a ton of problems. (Though if you're mucking around with memory addresses, you're probably not using `COMPATIBILITY` in the first place...)