### PR TITLE
LDY_abs fix, boss enemy stuff

### DIFF
--- a/config.asm
+++ b/config.asm
@@ -134,6 +134,9 @@ PRESERVE_UNUSED_SPACE = 1
 ; Encode world tileset in unused 3 bits of area header byte 2
 ; AREA_HEADER_TILESET = 1
 
+; Checks the CHR latch variable to reload the CHR data
+; RESET_CHR_LATCH = 1
+
 ; Encode level engine object mode switch in unused 2 bits of area header byte 4
 ; ENABLE_LEVEL_OBJECT_MODE = 1
 

--- a/docs/enemies.md
+++ b/docs/enemies.md
@@ -1,0 +1,102 @@
+## Object/Enemy RAM
+
+### `$0015`  (`ObjectXHi`)
+- high byte for x-position
+
+### `$001F`  (`ObjectYHi`)
+- high byte for y-position
+
+### `$0029`  (`ObjectXLo`)
+- low byte for x-position
+
+### `$0032`  (`ObjectYLo`)
+- low byte for y-position
+
+### `$003D`  (`ObjectXVelocity`)
+- x-velocity
+
+### `$0047`  (`ObjectYVelocity`)
+- y-velocity
+
+### `$0051`  (`EnemyState`)
+- enemy state (eg. alive/dead/puff of smoke)
+
+### `$005B`  (`EnemyCollision`)
+- enemy collision flags
+
+### `$0065`  (`ObjectAttributes`)
+- attributes used for rendering an object (eg. mirroring, size, layering)
+
+### `$006F`  (`EnemyMovementDirection`)
+- direction of enemy movement (used for velocity lookups)
+
+### `$0079`  (`EnemyVariable`)
+- Birdo type
+- Whether item is attached to Birdo
+- Mushroom index
+- Tweeter bounce counter
+- Background tile for Mushroom Block
+- Starting y-position for falling logs
+- Clawgrip's movement cycle
+- Cobrat target Y
+- Pokey number of segments
+- Fryguy's movement cycle?
+- Whale spout timer?
+- Wart's movement cycle
+
+### `$0086`  (`EnemyTimer`)
+- BobOmb fuse
+- Bomb fuse
+- Panser spit
+- Trouter jump
+- Birdo spit
+- Puff of smoke
+- Block fizzle
+- Pidgit dive
+- ...
+
+### `$0090`  (`ObjectType`)
+- enemy type ID
+
+### `$009F`  (`ObjectAnimationTimer`)
+- time animation frames
+
+### `$00A8`  (`ObjectBeingCarriedTimer`)
+
+### `$00B1`  (`EnemyArray_B1`)
+
+### `$00D9` (`EnemyArray_D9`)
+
+### `$042F` (`EnemyArray_42F`)
+ - stun timer
+
+### `$0438` (`EnemyArray_438`)
+
+### `$0453` (`EnemyArray_453`)
+
+### `$045C` (`EnemyArray_45C`)
+  - flashing timer
+
+### `$0465` (`EnemyHP`)
+
+### `$046E` (`EnemyArray_46E`)
+
+### `$0477` (`EnemyArray_477`)
+
+### `$0480` (`EnemyArray_480`)
+
+### `$0489` (`EnemyArray_489`)
+
+### `$0492` (`EnemyArray_492`)
+
+### `$049B` (`EnemyArray_SpawnsDoor`)
+- if set, an end-of-level door spawns when the enemy is defeated
+
+### `$04A4` (`unk_RAM_4A4`)
+
+### `$04CC` (`ObjectXAcceleration`)
+
+### `$04D6` (`ObjectYAcceleration`)
+
+### `$04EF` (`unk_RAM_4EF`)
+

--- a/src/compatibility-shims.asm
+++ b/src/compatibility-shims.asm
@@ -67,7 +67,7 @@ MACRO LDY_abs addr
 		.db $ac
 		.dw addr
 	ELSE
-		LDX addr
+		LDY addr
 		NOP_compat
 	ENDIF
 ENDM

--- a/src/prg-0-1.asm
+++ b/src/prg-0-1.asm
@@ -7363,7 +7363,7 @@ CreateEnemy_Bank1_FoundSlot:
 	LDA #EnemyState_Alive
 	STA EnemyState, Y
 	LSR A
-	STA unk_RAM_49B, Y
+	STA EnemyArray_SpawnsDoor, Y
 	LDA #Enemy_ShyguyRed
 	STA ObjectType, Y
 	LDA ObjectXLo, X

--- a/src/prg-2-3.asm
+++ b/src/prg-2-3.asm
@@ -68,6 +68,12 @@ AreaInitialization:
 	STA QuicksandDepth
 	STA BossBeaten
 
+IFDEF RESET_CHR_LATCH
+	LDY #$FF
+	STY BossTileset
+	INC ResetCHRLatch
+ENDIF
+
 	LDY #$1B
 AreaInitialization_CarryYOffsetLoop:
 	; Copy the global carrying Y offsets to memory
@@ -263,6 +269,10 @@ loc_BANK2_8164:
 
 loc_BANK2_816C:
 	JSR loc_BANK2_8256
+
+IFDEF RESET_CHR_LATCH
+	JSR CheckResetCHRLatch
+ENDIF
 
 	LDA StopwatchTimer
 	BEQ loc_BANK2_8185
@@ -6444,6 +6454,11 @@ ENDIF
 EnemyInit_Clawgrip:
 	JSR EnemyInit_Birdo
 
+IFDEF RESET_CHR_LATCH
+	LDA #$03
+	JSR SetBossTileset
+ENDIF
+
 	LDA #$04
 	STA EnemyHP, X
 	LDA #$00
@@ -7287,6 +7302,11 @@ loc_BANK3_A55F:
 EnemyInit_Mouser:
 	JSR EnemyInit_Birdo
 
+IFDEF RESET_CHR_LATCH
+	LDA #$00
+	JSR SetBossTileset
+ENDIF
+
 	LDA #$02
 	LDY CurrentWorldTileset
 	BEQ EnemyInit_Mouser_SetHP
@@ -7616,6 +7636,11 @@ loc_BANK3_A71E:
 
 EnemyInit_Tryclyde:
 	JSR EnemyInit_Basic
+
+IFDEF RESET_CHR_LATCH
+	LDA #$01
+	JSR SetBossTileset
+ENDIF
 
 	LDA #$40
 	STA EnemyArray_477, X
@@ -8596,6 +8621,11 @@ loc_BANK3_AC67:
 
 EnemyInit_Fryguy:
 	JSR EnemyInit_Basic
+
+IFDEF RESET_CHR_LATCH
+	LDA #$02
+	JSR SetBossTileset
+ENDIF
 
 	LDA #$04
 	STA EnemyHP, X
@@ -9578,6 +9608,11 @@ locret_BANK3_B1CC:
 
 EnemyInit_Wart:
 	JSR EnemyInit_Basic
+
+IFDEF RESET_CHR_LATCH
+	LDA #$04
+	JSR SetBossTileset
+ENDIF
 
 	LDA #$06
 	STA EnemyHP, X
@@ -11988,6 +12023,15 @@ AreaSecondaryRoutine_POW_OffsetScreen:
 
 AreaSecondaryRoutine_Exit:
 	RTS
+
+
+IFDEF RESET_CHR_LATCH
+SetBossTileset:
+	STA BossTileset
+	INC ResetCHRLatch
+	RTS
+ENDIF
+
 
 IFDEF CONTROLLER_2_DEBUG
 ;

--- a/src/prg-2-3.asm
+++ b/src/prg-2-3.asm
@@ -706,10 +706,10 @@ loc_BANK2_8361:
 	STA ObjectXHi, X
 
 loc_BANK2_8377:
-	STA unk_RAM_49B, X
+	STA EnemyArray_SpawnsDoor, X
 	STY byte_RAM_C
 	LDA (RawEnemyData), Y
-	AND #$3F
+	AND #%00111111
 	CMP #$32
 	BCS loc_BANK2_8393
 
@@ -727,15 +727,15 @@ loc_BANK2_8393:
 	; enable bit 7 of the raw enemy data to indicate that the enemy has spawned
 	LDY byte_RAM_C
 	LDA (RawEnemyData), Y
-	ORA #$80
+	ORA #%10000000
 	STA (RawEnemyData), Y
 
-	CMP #$DC
-	AND #$7F
+	CMP #%10000000 | Enemy_BossBirdo
+	AND #%01111111
 	BCC loc_BANK2_83A6
 
-	AND #$3F
-	STA unk_RAM_49B, X
+	AND #%00111111
+	STA EnemyArray_SpawnsDoor, X
 
 loc_BANK2_83A6:
 	STA ObjectType, X
@@ -981,7 +981,7 @@ loc_BANK2_8500:
 	LDA EnemyState, X
 	BNE MakeEnemyFlipUpsideDown
 
-	LDA unk_RAM_49B, X
+	LDA EnemyArray_SpawnsDoor, X
 	BEQ EnemyDeathMaybe
 
 loc_BANK2_8509:
@@ -1533,7 +1533,7 @@ loc_BANK2_87AC:
 	LDA byte_BANK2_8798, Y
 	JSR RenderSprite_DrawObject
 
-	LDA unk_RAM_49B, X
+	LDA EnemyArray_SpawnsDoor, X
 	BEQ locret_BANK2_8797
 
 	LDA EnemyTimer, X
@@ -1634,7 +1634,7 @@ loc_BANK2_8842:
 	DEC FryguySplitFlames
 	BPL loc_BANK2_8855
 
-	INC unk_RAM_49B, X
+	INC EnemyArray_SpawnsDoor, X
 	INC ObjectType, X
 	JMP loc_BANK2_8509
 
@@ -3106,7 +3106,7 @@ loc_BANK2_8FA3:
 	BNE loc_BANK2_8FB6
 
 	LDA byte_RAM_EE
-	AND #$C
+	AND #$0C
 	BNE loc_BANK2_8FB6
 
 	LDA #$1C
@@ -3773,7 +3773,7 @@ CreateEnemy_FoundSlot:
 	LDA #EnemyState_Alive
 	STA EnemyState, Y
 	LSR A
-	STA unk_RAM_49B, Y
+	STA EnemyArray_SpawnsDoor, Y
 	LDA #Enemy_ShyguyRed
 	STA ObjectType, Y
 	LDA ObjectXLo, X
@@ -4248,7 +4248,7 @@ loc_BANK2_9503:
 	BNE loc_BANK2_9528 ; If not, go handle some other enemies
 
 	; ...but very, very, very rarely, only
-	; when their timer (that incremenets once per bounce)
+	; when their timer (that increments once per bounce)
 	; hits #$3F -- almost unnoticable
 	LDA #$3F
 	JSR sub_BANK2_9599

--- a/src/prg-c-d.asm
+++ b/src/prg-c-d.asm
@@ -397,7 +397,7 @@ loc_BANKC_8402:
 	LDA MarioDream_WakingFrames, Y
 	STA BackgroundCHR1
 	CLC
-	ADC #2
+	ADC #$02
 	STA BackgroundCHR2
 	LDA MarioDream_WakingFrameCounts, Y
 	STA byte_RAM_10
@@ -429,9 +429,7 @@ loc_BANKC_8435:
 	LDA MarioDream_SnoringFrames, Y
 	STA BackgroundCHR1
 	CLC
-	ADC #2
-
-loc_BANKC_8440:
+	ADC #$02
 	STA BackgroundCHR2
 	LDA MarioDream_SnoringFrameCounts, Y
 	STA byte_RAM_10
@@ -472,7 +470,7 @@ loc_BANKC_846D:
 	LDA MarioDream_SnoringFrames, Y
 	STA BackgroundCHR1
 	CLC
-	ADC #2
+	ADC #$02
 	STA BackgroundCHR2
 	LDA MarioDream_SnoringFrameCounts, Y
 	STA byte_RAM_10

--- a/src/ram.asm
+++ b/src/ram.asm
@@ -969,7 +969,7 @@ EnemyArray_492:
 
 ; FOR RENT
 	.dsb 1 ; $049a
-unk_RAM_49B:
+EnemyArray_SpawnsDoor:
 	.dsb 1 ; $049b
 	.dsb 1 ; $049c
 	.dsb 1 ; $049d

--- a/src/ram.asm
+++ b/src/ram.asm
@@ -749,6 +749,7 @@ SpriteFlickerSlot:
 ; FOR RENT
 	.dsb 1 ; $0401
 ; FOR RENT
+BossTileset:
 	.dsb 1 ; $0402
 ; FOR RENT
 	.dsb 1 ; $0403
@@ -1945,6 +1946,7 @@ SpriteCHR4:
 BackgroundCHR2Timer:
 	.dsb 1 ; $06fd
 ; FOR RENT
+ResetCHRLatch:
 	.dsb 1 ; $06fe
 ; FOR RENT
 	.dsb 1 ; $06ff


### PR DESCRIPTION
* Fixes `LDY_abs`, which was using the wrong op in `COMPATIBILITY` mode
* Adds labels for the boss door spawning and some general enemy behavior notes
* Adds `RESET_CHR_LATCH` flag, which adds a hook for boss enemies to load a CHR bank for the enemy sprites table. It works using a target bank ID and a latch variable to indicate whether the game should swap the graphics. This is a little weird out of the box since the bank it's swapping isn't actually where the boss sprites are, but the intention is that the boss tiles would be moved away from the backgrounds to facilitate an on-demand swap of regular enemies to boss enemies when necessary.