### PR TITLE
Various disassembly updates

### DIFF
--- a/config.asm
+++ b/config.asm
@@ -1,3 +1,5 @@
+.ignorenl
+
 ; ----------------------------------------
 ;  Super Mario Bros. 2 Disassembly Config
 ; ----------------------------------------
@@ -161,3 +163,6 @@ PRESERVE_UNUSED_SPACE = 1
 
 ; Enables full-page door/vine searching so that entrances don't need to align
 ; ROBUST_TRANSITION_SEARCH = 1
+
+
+.endinl

--- a/docs/enemies.md
+++ b/docs/enemies.md
@@ -65,8 +65,6 @@
 
 ### `$00B1`  (`EnemyArray_B1`)
 
-### `$00D9` (`EnemyArray_D9`)
-
 ### `$042F` (`EnemyArray_42F`)
  - stun timer
 

--- a/smb2.asm
+++ b/smb2.asm
@@ -38,7 +38,7 @@ IF INES_MAPPER == MAPPER_FME7
 	.db (INES_MAPPER & %00001111) << 4 ; mapper (lower nybble) and mirroring
 	.db (INES_MAPPER & %11110000) | %1000 ; mapper (upper nybble) and iNES 2.0
 	.dsb 2, $00
-	.db $70 ; flags 10
+	.db $77 ; flags 10
 	.dsb 5, $00 ; clear the remaining bytes
 ELSEIF INES_MAPPER == MAPPER_MMC5
 	.db (INES_MAPPER & %00001111) << 4 | %10 ; mapper (lower nybble) and mirroring

--- a/smb2.asm
+++ b/smb2.asm
@@ -8,6 +8,7 @@
 .include "config.asm"
 .include "constants.asm"
 
+.ignorenl
 INES_MAPPER = MAPPER_MMC3
 IFDEF FME7
 	INES_MAPPER = MAPPER_FME7
@@ -15,6 +16,7 @@ ENDIF
 IFDEF MMC5
 	INES_MAPPER = MAPPER_MMC5
 ENDIF
+.endinl
 
 ; -----------------------------------------
 ; Add NES header

--- a/src/prg-0-1.asm
+++ b/src/prg-0-1.asm
@@ -4325,22 +4325,52 @@ AreaTransitionPlacement_Reset:
 	STA byte_RAM_E6
 	LDA CurrentLevelEntryPage
 	STA byte_RAM_E8
+
+IFDEF LEVEL_ENGINE_UPGRADES
+	LDX IsHorizontalLevel
+	BEQ AreaTransitionPlacement_Reset_FindOpenSpace
+
+	; Find non-sky to use as the ground
+	LDA #$E0
+	STA byte_RAM_E6
+
+AreaTransitionPlacement_Reset_FindStandableTile:
 	LDA #$0C
 	STA byte_RAM_3
-
-loc_BANK0_94F8:
+AreaTransitionPlacement_Reset_FindStandableTileLoop:
 	JSR SetTileOffsetAndAreaPageAddr_Bank1
 
 	LDY byte_RAM_E7
 	LDA (byte_RAM_1), Y
-	CMP #$40
+	CMP #BackgroundTile_Sky
+	BNE AreaTransitionPlacement_Reset_FindOpenSpaceLoop
+
+	JSR AreaTransitionPlacement_MovePlayerUp1Tile
+
+	STA byte_RAM_E6
+	DEC byte_RAM_3
+	BNE AreaTransitionPlacement_Reset_FindStandableTileLoop
+ENDIF
+
+;
+; The player must start in empty space (not a wall)
+;
+AreaTransitionPlacement_Reset_FindOpenSpace:
+	LDA #$0C
+	STA byte_RAM_3
+AreaTransitionPlacement_Reset_FindOpenSpaceLoop:
+	JSR SetTileOffsetAndAreaPageAddr_Bank1
+
+	LDY byte_RAM_E7
+	LDA (byte_RAM_1), Y
+	CMP #BackgroundTile_Sky
 	BEQ AreaTransitionPlacement_MovePlayerUp1Tile
 
 	JSR AreaTransitionPlacement_MovePlayerUp1Tile
 
 	STA byte_RAM_E6
 	DEC byte_RAM_3
-	BNE loc_BANK0_94F8
+	BNE AreaTransitionPlacement_Reset_FindOpenSpaceLoop
 
 
 ;

--- a/src/prg-0-1.asm
+++ b/src/prg-0-1.asm
@@ -3271,6 +3271,7 @@ PlayerTileCollision_CheckCherryAndClimbable:
 
 	; byte_RAM_10 seems to be a global counter
 	; this code increments Y every other frame, but why?
+	; Seems like it alternates between doing the check on the left or right side each frame.
 	LDA byte_RAM_10
 	LSR A
 	BCS PlayerTileCollision_CheckCherryAndClimbable_AfterTick
@@ -3794,7 +3795,7 @@ sub_BANK0_924F:
 	LDA #$00
 	STA byte_RAM_0
 	STA byte_RAM_1
-	LDA byte_BANKF_F011, Y
+	LDA VerticalTileCollisionHitboxX, Y
 	BPL loc_BANK0_925E
 
 	DEC byte_RAM_0
@@ -3816,23 +3817,19 @@ loc_BANK0_925E:
 	STA byte_RAM_2
 	STA byte_RAM_3
 	LDA IsHorizontalLevel
-
-loc_BANK0_9277:
 	BNE loc_BANK0_927D
 
 	STA byte_RAM_2
 	STA byte_RAM_3
 
 loc_BANK0_927D:
-	LDA byte_BANKF_F055, Y
+	LDA VerticalTileCollisionHitboxY, Y
 	BPL loc_BANK0_9284
 
 	DEC byte_RAM_1
 
 loc_BANK0_9284:
 	CLC
-
-loc_BANK0_9285:
 	ADC PlayerYLo, X
 	AND #$F0
 	STA byte_RAM_6

--- a/src/prg-0-1.asm
+++ b/src/prg-0-1.asm
@@ -33,10 +33,10 @@ loc_BANK0_8013:
 
 loc_BANK0_8016:
 	ORA #$C0
-	STA byte_RAM_CF
+	STA BackgroundUpdateBoundaryBackward
 	SEC
 	SBC #$40
-	STA byte_RAM_CE
+	STA BackgroundUpdateBoundary
 	LDA CurrentLevelEntryPage
 
 loc_BANK0_8022:
@@ -49,29 +49,35 @@ loc_BANK0_8022:
 
 loc_BANK0_802B:
 	ORA #$10
-	STA byte_RAM_D0
+	STA BackgroundUpdateBoundaryForward
 	LDA CurrentLevelEntryPage
 	LDY #$00
 	JSR ResetPPUScrollHi
 
 	LDA #$20
-	STA byte_RAM_D3
+	STA DrawBackgroundTilesPPUAddrLoBackward
 	LDA #$60
-	STA byte_RAM_D4
+	STA DrawBackgroundTilesPPUAddrLoForward
+
+	; Set the flag for the initial screen render
 	INC byte_RAM_502
+
+	; Initialize the PPU update boundary
 	LDA #$E0
 	STA byte_RAM_E2
 	LDA #$01
 	STA byte_RAM_E4
 	STA byte_RAM_53A
 	LSR A
-	STA byte_RAM_D2
+	STA DrawBackgroundTilesPPUAddrLo
+
+	; Set the screen y-position
 	LDY CurrentLevelEntryPage
 	JSR PageHeightCompensation
-
 	STA ScreenYLo
 	STY ScreenYHi
 
+	; Cue player transition
 	JSR ApplyAreaTransition
 
 loc_BANK0_805D:
@@ -79,34 +85,39 @@ loc_BANK0_805D:
 	STA byte_RAM_6
 	LDA #$FF
 	STA byte_RAM_505
-
-loc_BANK0_8066:
 	LDA #$A0
-	STA byte_RAM_507
+	STA PPUScrollCheckLo
+
 	JSR sub_BANK0_823D
 
 	LDA byte_RAM_53A
-	BNE locret_BANK0_8082
+	BNE InitializeAreaVertical_Exit
 
+	; Initial screen render is complete
 	INC BreakStartLevelLoop
+
 	LDA #$E8
 	STA byte_RAM_E1
 	LDA #$C8
 	STA byte_RAM_E2
+
 	LDA #$00
 	STA byte_RAM_502
 
-locret_BANK0_8082:
+InitializeAreaVertical_Exit:
 	RTS
 
 
-; =============== S U B R O U T I N E =======================================
-
-sub_BANK0_8083:
+;
+; Applies vertical screen scrolling if `DetermineVerticalScroll` indicated that
+; it was necessary.
+;
+ApplyVerticalScroll:
 	LDA NeedsScroll
 	AND #%00000100
 	BNE loc_BANK0_809D
 
+	;	Not currently in a scroll interval
 	LDA NeedsScroll
 	AND #%00000111
 	BNE loc_BANK0_8092
@@ -130,7 +141,7 @@ loc_BANK0_809D:
 
 	BNE loc_BANK0_80B1
 
-	LDA byte_RAM_CF
+	LDA BackgroundUpdateBoundaryBackward
 	AND #$0F
 	CMP #$09
 	BNE loc_BANK0_80B1
@@ -189,14 +200,14 @@ loc_BANK0_80E2:
 	BNE loc_BANK0_80FB
 
 	LDX #$00
-	JSR sub_BANK0_8297
+	JSR DecrementVerticalScrollRow
 
 	LDX #$01
-	JSR sub_BANK0_8297
+	JSR DecrementVerticalScrollRow
 
 loc_BANK0_80FB:
 	LDX #$01
-	JSR sub_BANK0_82E2
+	JSR PrepareBackgroundDrawing_Vertical
 
 	JMP loc_BANK0_8170
 
@@ -218,7 +229,7 @@ loc_BANK0_8114:
 	INC byte_RAM_F
 
 loc_BANK0_8116:
-	LDA byte_RAM_D0
+	LDA BackgroundUpdateBoundaryForward
 	AND #$0F
 	CMP byte_RAM_F
 	BNE loc_BANK0_8121
@@ -272,19 +283,19 @@ loc_BANK0_8152:
 	DEX
 	JSR sub_BANK0_828F
 
-	LDA byte_RAM_D4
+	LDA DrawBackgroundTilesPPUAddrLoForward
 	AND #$20
 	BNE loc_BANK0_816B
 
 	LDX #$02
-	JSR sub_BANK0_82BE
+	JSR IncrementVerticalScrollRow
 
 	LDX #$01
-	JSR sub_BANK0_82BE
+	JSR IncrementVerticalScrollRow
 
 loc_BANK0_816B:
 	LDX #$02
-	JSR sub_BANK0_82E2
+	JSR PrepareBackgroundDrawing_Vertical
 
 loc_BANK0_8170:
 	LDA CameraScrollTiles
@@ -313,7 +324,7 @@ loc_BANK0_818A:
 
 loc_BANK0_818F:
 	; Update PPU for scrolling
-	JSR sub_BANK0_833E
+	JSR CopyBackgroundToPPUBuffer_Vertical
 
 	DEC CameraScrollTiles
 	BNE locret_BANK0_81A0
@@ -328,7 +339,6 @@ loc_BANK0_819C:
 locret_BANK0_81A0:
 	RTS
 
-; End of function sub_BANK0_8083
 
 ; ---------------------------------------------------------------------------
 	.db $01
@@ -384,7 +394,7 @@ RestoreScreenScrollPosition:
 
 ; Used for redrawing the screen in a vertical area after unpausing
 sub_BANK0_81FE:
-	LDA byte_RAM_CF
+	LDA BackgroundUpdateBoundaryBackward
 	AND #$10
 	BEQ loc_BANK0_820B
 
@@ -396,24 +406,24 @@ sub_BANK0_81FE:
 loc_BANK0_820B:
 	LDA #$01
 	STA byte_RAM_E4
-	LDA byte_RAM_CF
-	STA byte_RAM_CE
+	LDA BackgroundUpdateBoundaryBackward
+	STA BackgroundUpdateBoundary
 	LDA #$10
 	STA byte_RAM_1
 	LDX #$00
 	JSR sub_BANK0_8314
 
-	LDA byte_RAM_D3
-	STA byte_RAM_D2
+	LDA DrawBackgroundTilesPPUAddrLoBackward
+	STA DrawBackgroundTilesPPUAddrLo
 	LDA byte_RAM_E1
 	STA byte_RAM_E2
 	LDX #$01
 	JSR sub_BANK0_846A
 
 	LDA #$F0
-	STA byte_RAM_506
-	STA byte_RAM_507
-	LDA byte_RAM_D0
+	STA PPUScrollCheckHi
+	STA PPUScrollCheckLo
+	LDA BackgroundUpdateBoundaryForward
 	STA byte_RAM_505
 	INC byte_RAM_D5
 	LDA #$01
@@ -423,24 +433,26 @@ loc_BANK0_820B:
 
 ; Used for redrawing the background tiles in a vertical area
 sub_BANK0_823D:
+	; Clear the flag to indicate that we're drawing
 	LDX #$00
 	STX byte_RAM_537
-	JSR sub_BANK0_82E2
+
+	JSR PrepareBackgroundDrawing_Vertical
 
 	; Update PPU for area init
-	JSR sub_BANK0_833E
+	JSR CopyBackgroundToPPUBuffer_Vertical
 
 	LDX #$00
 	JSR sub_BANK0_828F
 
-	LDA byte_RAM_506
-	CMP byte_RAM_D1
+	LDA PPUScrollCheckHi
+	CMP DrawBackgroundTilesPPUAddrHi
 	BNE loc_BANK0_8277
 
-	LDA byte_RAM_507
+	LDA PPUScrollCheckLo
 	CLC
 	ADC #$20
-	CMP byte_RAM_D2
+	CMP DrawBackgroundTilesPPUAddrLo
 	BNE loc_BANK0_8277
 
 loc_BANK0_825E:
@@ -452,222 +464,260 @@ loc_BANK0_825E:
 	STA byte_RAM_E1
 
 loc_BANK0_8268:
+	; Set the flag to indicate that we've finished drawing
 	INC byte_RAM_537
+
 	LDA #$00
 	STA byte_RAM_53A, X
 	STA byte_RAM_53D
 	STA byte_RAM_53E
+
 	RTS
 
 ; ---------------------------------------------------------------------------
 
 loc_BANK0_8277:
-	LDA byte_RAM_D2
+	LDA DrawBackgroundTilesPPUAddrLo
 	AND #$20
 	BNE locret_BANK0_828E
 
-	LDA byte_RAM_CE
+	LDA BackgroundUpdateBoundary
 	CMP byte_RAM_505
 	BEQ loc_BANK0_825E
 
-	JMP sub_BANK0_82BE
+	JMP IncrementVerticalScrollRow
 
 ; ---------------------------------------------------------------------------
 
+; Decrement tiles row
 loc_BANK0_8287:
-	LDA byte_RAM_D3, X
+	LDA DrawBackgroundTilesPPUAddrLoBackward, X
 	SEC
 	SBC #$20
-	STA byte_RAM_D3, X
+	STA DrawBackgroundTilesPPUAddrLoBackward, X
 
 locret_BANK0_828E:
 	RTS
 
-; End of function sub_BANK0_823D
 
-; =============== S U B R O U T I N E =======================================
-
+; Increment tiles row
 sub_BANK0_828F:
-	LDA byte_RAM_D2, X
+	LDA DrawBackgroundTilesPPUAddrLo, X
 	CLC
 	ADC #$20
-	STA byte_RAM_D2, X
+	STA DrawBackgroundTilesPPUAddrLo, X
 	RTS
 
-; End of function sub_BANK0_828F
 
-; =============== S U B R O U T I N E =======================================
-
-sub_BANK0_8297:
-	LDA byte_RAM_CF, X
+;
+; Decrement the drawing boundary table entry by one row of tiles
+;
+DecrementVerticalScrollRow:
+	; Decrement the row offset
+	LDA BackgroundUpdateBoundaryBackward, X
 	SEC
 	SBC #$10
-	STA byte_RAM_CF, X
+	STA BackgroundUpdateBoundaryBackward, X
 	AND #$F0
 	CMP #$F0
-	BNE locret_BANK0_82BD
+	BNE DecrementVerticalScrollRow_Exit
 
-	LDA byte_RAM_CF, X
+	; Decrement the page
+	LDA BackgroundUpdateBoundaryBackward, X
 	AND #$0F
 	CLC
 	ADC #$E0
-	STA byte_RAM_CF, X
-	DEC byte_RAM_CF, X
-	LDA byte_RAM_CF, X
-	CMP #$0DF
+	STA BackgroundUpdateBoundaryBackward, X
+	DEC BackgroundUpdateBoundaryBackward, X
+	LDA BackgroundUpdateBoundaryBackward, X
+	CMP #$DF
 	BNE loc_BANK0_82B9
 
-loc_BANK0_82B5:
+	; Wrap around to the last row of the last page
 	LDA #$E9
-	STA byte_RAM_CF, X
+	STA BackgroundUpdateBoundaryBackward, X
 
+; @TODO: What's this doing, exactly?
 loc_BANK0_82B9:
 	LDA #$A0
-	STA byte_RAM_D3, X
+	STA DrawBackgroundTilesPPUAddrLoBackward, X
 
-locret_BANK0_82BD:
+DecrementVerticalScrollRow_Exit:
 	RTS
 
-; End of function sub_BANK0_8297
 
-; =============== S U B R O U T I N E =======================================
-
-sub_BANK0_82BE:
-	LDA byte_RAM_CE, X
+;
+; Increment the drawing boundary table entry by one column of tiles
+;
+IncrementVerticalScrollRow:
+	; Increment the row offset
+	LDA BackgroundUpdateBoundary, X
 	CLC
 	ADC #$10
-	STA byte_RAM_CE, X
+	STA BackgroundUpdateBoundary, X
 	AND #$F0
 	CMP #$F0
-	BNE locret_BANK0_82E1
+	BNE IncrementVerticalScrollRow_Exit
 
-	LDA byte_RAM_CE, X
+	; Increment the page
+	LDA BackgroundUpdateBoundary, X
 	AND #$0F
-	STA byte_RAM_CE, X
-	INC byte_RAM_CE, X
-	LDA byte_RAM_CE, X
+	STA BackgroundUpdateBoundary, X
+	INC BackgroundUpdateBoundary, X
+	LDA BackgroundUpdateBoundary, X
 	CMP #$0A
 	BNE loc_BANK0_82DD
 
+	; Wrap around to the first row of the first page
 	LDA #$00
-	STA byte_RAM_CE, X
+	STA BackgroundUpdateBoundary, X
 
+; @TODO: What's this doing, exactly?
 loc_BANK0_82DD:
 	LDA #$00
-	STA byte_RAM_D2, X
+	STA DrawBackgroundTilesPPUAddrLo, X
 
-locret_BANK0_82E1:
+IncrementVerticalScrollRow_Exit:
 	RTS
 
-; End of function sub_BANK0_82BE
 
-; =============== S U B R O U T I N E =======================================
-
-sub_BANK0_82E2:
-	LDA byte_RAM_CE, X
+;
+; Determines which background tiles from the decoded level data to draw to the
+; screen and where to draw them for vertical areas.
+;
+; ##### Input
+; - `BackgroundUpdateBoundary`: drawing boundary table
+; - `X`: drawing boundary index (`$00` = full, `$01` = up, `$02` = down)
+;
+; ##### Output
+; - `ReadLevelDataAddress`: decoded level data address
+; - `ReadLevelDataOffset`: level data offset
+; - `DrawBackgroundTilesPPUAddrHi`/`DrawBackgroundTilesPPUAddrLo`: PPU start address
+;
+PrepareBackgroundDrawing_Vertical:
+	; Lower nybble is used for page
+	LDA BackgroundUpdateBoundary, X
 	AND #$0F
 	TAY
+	; Get the address of the decoded level data
 	LDA DecodedLevelPageStartLo_Bank1, Y
-	STA byte_RAM_E9
+	STA ReadLevelDataAddress
 	LDA DecodedLevelPageStartHi_Bank1, Y
-	STA byte_RAM_EA
-	LDA byte_RAM_CE, X
+	STA ReadLevelDataAddress + 1
+
+	; Upper nybble is used for the tile offset (rows)
+	LDA BackgroundUpdateBoundary, X
 	AND #$F0
-	STA byte_RAM_D7
-	LDA byte_RAM_CE, X
+	STA ReadLevelDataOffset
+
+	; Determine where on the screen we should draw the tile
+	LDA BackgroundUpdateBoundary, X
 	LSR A
-	BCC loc_BANK0_8300
+	BCC PrepareBackgroundDrawing_Vertical_Nametable2800
 
 	LDA #$20
-	BNE loc_BANK0_8302
+	BNE PrepareBackgroundDrawing_Vertical_SetNametableHi
 
-loc_BANK0_8300:
+PrepareBackgroundDrawing_Vertical_Nametable2800:
 	LDA #$28
 
-loc_BANK0_8302:
-	STA byte_RAM_D1
-	LDA byte_RAM_CE, X
+PrepareBackgroundDrawing_Vertical_SetNametableHi:
+	STA DrawBackgroundTilesPPUAddrHi
+
+	LDA BackgroundUpdateBoundary, X
 	AND #$C0
 	ASL A
 	ROL A
 	ROL A
-	ADC byte_RAM_D1
-	STA byte_RAM_D1
+	ADC DrawBackgroundTilesPPUAddrHi
+	STA DrawBackgroundTilesPPUAddrHi
 
-loc_BANK0_830F:
-	LDA byte_RAM_D2, X
-	STA byte_RAM_D2
+	LDA DrawBackgroundTilesPPUAddrLo, X
+	STA DrawBackgroundTilesPPUAddrLo
 
-locret_BANK0_8313:
+PrepareBackgroundDrawing_Vertical_Exit:
 	RTS
 
-; End of function sub_BANK0_82E2
 
+;
 ; =============== S U B R O U T I N E =======================================
-
+;
 sub_BANK0_8314:
-	LDA byte_RAM_CE, X
+	LDA BackgroundUpdateBoundary, X
 	AND #$10
-	BEQ locret_BANK0_8313
+	BEQ PrepareBackgroundDrawing_Vertical_Exit
 
-	LDA byte_RAM_CE, X
+	LDA BackgroundUpdateBoundary, X
 	STA byte_RAM_3
 	SEC
 	SBC byte_RAM_1
-	STA byte_RAM_CE, X
-	JSR sub_BANK0_82E2
+	STA BackgroundUpdateBoundary, X
+	JSR PrepareBackgroundDrawing_Vertical
 
+; loop through tiles to generate PPU attribute data
 loc_BANK0_8326:
 	LDA #$0F
-	STA byte_RAM_E3
+	STA PPUAttributeUpdateCounter
 	LDA #$00
-	STA byte_RAM_D6
+	STA CopyBackgroundCounter
 
 loc_BANK0_832E:
-	JSR sub_BANK0_84AC
+	JSR ReadNextTileAndSetPaletteInPPUAttribute
 
-	LDA byte_RAM_E3
+	LDA PPUAttributeUpdateCounter
 	BPL loc_BANK0_832E
 
 	LDA byte_RAM_3
-	STA byte_RAM_CE, X
+	STA BackgroundUpdateBoundary, X
 	DEC byte_RAM_E4
-	JMP sub_BANK0_82E2
+	JMP PrepareBackgroundDrawing_Vertical
 
-; End of function sub_BANK0_8314
 
-; =============== S U B R O U T I N E =======================================
-
-sub_BANK0_833E:
+;
+; This draws ground tiles to the PPU buffer
+;
+; ##### Input
+; - `byte_RAM_300`: offset in PPU buffer
+; - `DrawBackgroundTilesPPUAddrHi`/`DrawBackgroundTilesPPUAddrLo`: PPU start address
+; - `ReadLevelDataAddress`: decoded level data address
+; - `ReadLevelDataOffset`: level data offset
+;
+CopyBackgroundToPPUBuffer_Vertical:
+	; Set the PPU start address (ie. where we're going to draw tiles)
 	LDX byte_RAM_300
-	LDA byte_RAM_D1
+	LDA DrawBackgroundTilesPPUAddrHi
 	STA PPUBuffer_301, X
 	INX
-	LDA byte_RAM_D2
+	LDA DrawBackgroundTilesPPUAddrLo
 	STA PPUBuffer_301, X
 	INX
+
+	; We're going to draw a full row of tiles on the screen
 	LDA #$20
 	STA PPUBuffer_301, X
+
+	; Prepare the counters
 	INX
 	LDA #$00
-	STA byte_RAM_D6
+	STA CopyBackgroundCounter
 	LDA #$0F
-	STA byte_RAM_E3
-	LDA byte_RAM_D5
-	BEQ loc_BANK0_836C
+	STA PPUAttributeUpdateCounter
 
-	LDY byte_RAM_D7
+	LDA byte_RAM_D5
+	BEQ CopyBackgroundToPPUBuffer_Vertical_Loop
+
+	LDY ReadLevelDataOffset
 	CPY #$E0
-	BNE loc_BANK0_836C
+	BNE CopyBackgroundToPPUBuffer_Vertical_Loop
 
 	LDA #$00
 	STA byte_RAM_E4
-	INC byte_RAM_539
+	INC UpdatingPPUAttributeBottomRow
 
-loc_BANK0_836C:
-	LDY byte_RAM_D7
-	LDA (byte_RAM_E9), Y
-	STA byte_RAM_51B
+CopyBackgroundToPPUBuffer_Vertical_Loop:
+	LDY ReadLevelDataOffset
+	LDA (ReadLevelDataAddress), Y
+	STA DrawTileId
 	AND #%11000000
 	ASL A
 	ROL A
@@ -678,8 +728,8 @@ loc_BANK0_836C:
 	STA byte_RAM_0
 	LDA TileQuadPointersHi, Y
 	STA byte_RAM_1
-	LDY byte_RAM_D7
-	LDA (byte_RAM_E9), Y
+	LDY ReadLevelDataOffset
+	LDA (ReadLevelDataAddress), Y
 	ASL A
 	ASL A
 	TAY
@@ -693,23 +743,24 @@ loc_BANK0_8390:
 	; Write the tile to the PPU buffer
 	LDA (byte_RAM_0), Y
 	STA PPUBuffer_301, X
-	INC byte_RAM_D6
+	INC CopyBackgroundCounter
 	INX
 	INY
-	LDA byte_RAM_D6
+	LDA CopyBackgroundCounter
 	LSR A
 	BCS loc_BANK0_8390
 
-	INC byte_RAM_D7
+	INC ReadLevelDataOffset
 	LDA byte_RAM_D5
 	BEQ loc_BANK0_83A7
 
-	JSR sub_BANK0_8488
+	JSR SetTilePaletteInPPUAttribute
 
 loc_BANK0_83A7:
-	LDA byte_RAM_D6
+	; Did we finish drawing the row yet?
+	LDA CopyBackgroundCounter
 	CMP #$20
-	BCC loc_BANK0_836C
+	BCC CopyBackgroundToPPUBuffer_Vertical_Loop
 
 	LDA #$00
 	STA PPUBuffer_301, X
@@ -730,19 +781,19 @@ loc_BANK0_83C2:
 	LSR A
 	BCS loc_BANK0_83D4
 
+; down
 	LDX #$01
-	JSR sub_BANK0_8412
+	JSR CopyBackgroundAttributesToPPUBuffer_Vertical
 
 	LDX #$01
 	JSR sub_BANK0_846A
 
 	JMP loc_BANK0_83DE
 
-; ---------------------------------------------------------------------------
-
+; up
 loc_BANK0_83D4:
 	LDX #$00
-	JSR sub_BANK0_8412
+	JSR CopyBackgroundAttributesToPPUBuffer_Vertical
 
 	LDX #$00
 	JSR sub_BANK0_8478
@@ -753,13 +804,14 @@ loc_BANK0_83DE:
 	LSR A
 	BCC loc_BANK0_83FA
 
+; up
 	INX
-	LDA byte_RAM_CF, X
+	LDA BackgroundUpdateBoundaryBackward, X
 	AND #$F0
 	CMP #$E0
 	BEQ loc_BANK0_83F4
 
-	LDA byte_RAM_CF, X
+	LDA BackgroundUpdateBoundaryBackward, X
 	AND #$10
 	BNE loc_BANK0_840B
 
@@ -768,15 +820,14 @@ loc_BANK0_83F4:
 
 	JMP loc_BANK0_840B
 
-; ---------------------------------------------------------------------------
-
+; down
 loc_BANK0_83FA:
-	LDA byte_RAM_CF, X
+	LDA BackgroundUpdateBoundaryBackward, X
 	AND #$F0
 	CMP #$E0
 	BEQ loc_BANK0_8408
 
-	LDA byte_RAM_CF, X
+	LDA BackgroundUpdateBoundaryBackward, X
 	AND #$10
 	BEQ loc_BANK0_840B
 
@@ -789,80 +840,80 @@ loc_BANK0_840B:
 	STA byte_RAM_D5
 	RTS
 
-; End of function sub_BANK0_833E
 
-; =============== S U B R O U T I N E =======================================
-
-; something to do with background tile palettes in vertical levels?
-sub_BANK0_8412:
+;
+; This draws ground background attributes to the PPU buffer
+;
+CopyBackgroundAttributesToPPUBuffer_Vertical:
 	LDY byte_RAM_300
-	LDA byte_RAM_D1
+	; Setting the attribute address to update
+	LDA DrawBackgroundTilesPPUAddrHi
 	ORA #$03
 	STA PPUBuffer_301, Y
 	INY
 	LDA byte_RAM_E1, X
 	STA PPUBuffer_301, Y
 	INY
+	; We're updating 8 blocks of attribute data
 	LDA #$08
 	STA PPUBuffer_301, Y
 	INY
+
 	LDX #$07
+CopyBackgroundAttributesToPPUBuffer_Vertical_Loop:
+	LDA UpdatingPPUAttributeBottomRow
+	BEQ CopyBackgroundAttributesToPPUBuffer_Vertical_FullRow
 
-loc_BANK0_842B:
-	LDA byte_RAM_539
-	BEQ loc_BANK0_843B
-
-	LDA EnemyArray_D9, X
+CopyBackgroundAttributesToPPUBuffer_Vertical_HalfRow:
+	; Bottom row of PPU attributes has half-sized blocks
+  ; Shift background palettes down one quad
+	LDA ScrollingPPUAttributeUpdateBuffer, X
 	LSR A
 	LSR A
 	LSR A
 	LSR A
-	STA EnemyArray_D9, X
-	JMP loc_BANK0_8452
+	STA ScrollingPPUAttributeUpdateBuffer, X
+	JMP CopyBackgroundAttributesToPPUBuffer_Vertical_Next
 
-; ---------------------------------------------------------------------------
-
-loc_BANK0_843B:
+CopyBackgroundAttributesToPPUBuffer_Vertical_FullRow:
 	LDA NeedsScroll
 	LSR A
-	BCC loc_BANK0_8452
+	BCC CopyBackgroundAttributesToPPUBuffer_Vertical_Next
 
-loc_BANK0_8440:
-	LDA EnemyArray_D9, X
+CopyBackgroundAttributesToPPUBuffer_Vertical_Reverse:
+	; Swap palettes for upper and lower background quads, since tiles are drawn
+	; in the reverse order when scrolling up
+	LDA ScrollingPPUAttributeUpdateBuffer, X
 	ASL A
 	ASL A
 	ASL A
 	ASL A
 	STA byte_RAM_1
-	LDA EnemyArray_D9, X
+	LDA ScrollingPPUAttributeUpdateBuffer, X
 	LSR A
 	LSR A
 	LSR A
 	LSR A
 	ORA byte_RAM_1
+	STA ScrollingPPUAttributeUpdateBuffer, X
 
-loc_BANK0_8450:
-	STA EnemyArray_D9, X
-
-loc_BANK0_8452:
-	LDA EnemyArray_D9, X
+CopyBackgroundAttributesToPPUBuffer_Vertical_Next:
+	LDA ScrollingPPUAttributeUpdateBuffer, X
 	STA PPUBuffer_301, Y
 	INY
 	DEX
-	BPL loc_BANK0_842B
+	BPL CopyBackgroundAttributesToPPUBuffer_Vertical_Loop
 
 	LDA #$01
 	STA byte_RAM_E4
 	LSR A
-	STA byte_RAM_539
+	STA UpdatingPPUAttributeBottomRow
 	STA PPUBuffer_301, Y
 	STY byte_RAM_300
 	RTS
 
-; End of function sub_BANK0_8412
 
-; =============== S U B R O U T I N E =======================================
-
+; Increment attributes row
 sub_BANK0_846A:
 	LDA byte_RAM_E1, X
 	CLC
@@ -876,10 +927,8 @@ sub_BANK0_846A:
 locret_BANK0_8477:
 	RTS
 
-; End of function sub_BANK0_846A
 
-; =============== S U B R O U T I N E =======================================
-
+; Decrement attributes row
 sub_BANK0_8478:
 	LDA byte_RAM_E1, X
 	SEC
@@ -894,52 +943,69 @@ sub_BANK0_8478:
 locret_BANK0_8487:
 	RTS
 
-; End of function sub_BANK0_8478
 
-; =============== S U B R O U T I N E =======================================
-
-sub_BANK0_8488:
-	LDA byte_RAM_E3
+;
+; Sets the palette for the tile in the current PPU attribute block.
+; We effectively write these two bits at a time, since each attribute block
+; contains four background tiles.
+;
+; This subroutine is only used in vertical areas.
+;
+; ##### Input
+; - `DrawTileId`: tile ID to use for the palette
+; - `PPUAttributeUpdateCounter`: determines index to update in buffer
+;
+SetTilePaletteInPPUAttribute:
+	LDA PPUAttributeUpdateCounter
 	LSR A
 	TAY
-	LDA EnemyArray_D9, Y
+	; Shift two bits to the right to make room for the next tile
+	LDA ScrollingPPUAttributeUpdateBuffer, Y
 	LSR A
 	LSR A
-	STA EnemyArray_D9, Y
-	LDA byte_RAM_51B
-	AND #$C0
-	ORA EnemyArray_D9, Y
-	STA EnemyArray_D9, Y
-	DEC byte_RAM_E3
+	STA ScrollingPPUAttributeUpdateBuffer, Y
+	; Load the color for the next tile and apply it to the attribute value
+	LDA DrawTileId
+	AND #%11000000
+	ORA ScrollingPPUAttributeUpdateBuffer, Y
+	STA ScrollingPPUAttributeUpdateBuffer, Y
+
+	; Move on to the next block
+	DEC PPUAttributeUpdateCounter
 	RTS
 
-; End of function sub_BANK0_8488
 
-; ---------------------------------------------------------------------------
-
+; Unused?
 _code_04A2:
 	LDX #$07
 	LDA #$00
 
+; Unused?
 loc_BANK0_84A6:
-	STA EnemyArray_D9, X
+	STA ScrollingPPUAttributeUpdateBuffer, X
 	DEX
 	BNE loc_BANK0_84A6
 
 	RTS
 
-; =============== S U B R O U T I N E =======================================
 
+;
+; Loads a background tile from the level data and determines its PPU attribute data
+;
+; ##### Input
+; - `ReadLevelDataAddress`: decoded level data address
+;
+; ##### Output
+; - `DrawTileId` - tile ID
+;
+ReadNextTileAndSetPaletteInPPUAttribute:
 sub_BANK0_84AC:
-	LDY byte_RAM_D7
-	LDA (byte_RAM_E9), Y
-	STA byte_RAM_51B
-	INC byte_RAM_D7
-	JMP sub_BANK0_8488
+	LDY ReadLevelDataOffset
+	LDA (ReadLevelDataAddress), Y
+	STA DrawTileId
+	INC ReadLevelDataOffset
+	JMP SetTilePaletteInPPUAttribute
 
-; End of function sub_BANK0_84AC
-
-; ---------------------------------------------------------------------------
 
 ; Unused space in the original ($84B8 - $84FF)
 unusedSpace $8500, $FF
@@ -972,10 +1038,10 @@ loc_BANK0_851A:
 
 loc_BANK0_851D:
 	ORA #$D0
-	STA byte_RAM_CF
+	STA BackgroundUpdateBoundaryBackward
 	SEC
 	SBC #$20
-	STA byte_RAM_CE
+	STA BackgroundUpdateBoundary
 	LDA CurrentLevelEntryPage
 	CLC
 	ADC #$01
@@ -986,14 +1052,19 @@ loc_BANK0_851D:
 
 loc_BANK0_8532:
 	ORA #$10
-	STA byte_RAM_D0
+	STA BackgroundUpdateBoundaryForward
 	LDA CurrentLevelEntryPage
 	LDY #$01
 	JSR ResetPPUScrollHi
 
+	; Set the flag for the initial screen render
 	INC byte_RAM_502
+
+	; Set the screen x-position
 	LDA CurrentLevelEntryPage
 	STA ScreenBoundaryLeftHi
+
+	; Initialize the PPU update boundary
 	LDA #$01
 	STA byte_RAM_53A
 	LSR A
@@ -1001,19 +1072,20 @@ loc_BANK0_8532:
 	LDA #$FF
 	STA byte_RAM_505
 	LDA #$0F
-	STA byte_RAM_507
+	STA PPUScrollCheckLo
+
 	JSR sub_BANK0_856A
 
 loc_BANK0_855C:
 	JSR sub_BANK0_87AA
 
 	LDA byte_RAM_53A
-	BNE locret_BANK0_8569
+	BNE InitializeAreaHorizontal_Exit
 
 	STA byte_RAM_502
 	INC BreakStartLevelLoop
 
-locret_BANK0_8569:
+InitializeAreaHorizontal_Exit:
 	RTS
 
 
@@ -1052,7 +1124,7 @@ loc_BANK0_858F:
 	LDA CameraVelocityX
 	AND #$F0
 	CLC
-	ADC byte_RAM_CE, X
+	ADC BackgroundUpdateBoundary, X
 	PHP
 	ADC byte_RAM_B
 	PLP
@@ -1062,7 +1134,7 @@ loc_BANK0_858F:
 
 	BCC loc_BANK0_85C2
 
-	LDA byte_RAM_CE, X
+	LDA BackgroundUpdateBoundary, X
 	AND #$0F
 	CMP #$09
 	BNE loc_BANK0_85C2
@@ -1076,7 +1148,7 @@ loc_BANK0_858F:
 loc_BANK0_85B1:
 	BCS loc_BANK0_85C2
 
-	LDA byte_RAM_CE, X
+	LDA BackgroundUpdateBoundary, X
 	AND #$0F
 	BNE loc_BANK0_85C2
 
@@ -1091,7 +1163,7 @@ loc_BANK0_85C2:
 	LDA byte_RAM_C
 
 loc_BANK0_85C4:
-	STA byte_RAM_CE, X
+	STA BackgroundUpdateBoundary, X
 	DEX
 	BPL loc_BANK0_858F
 
@@ -1108,7 +1180,7 @@ loc_BANK0_85C4:
 	EOR #$01
 	STA PPUScrollXHiMirror
 	LDA #$01
-	STA byte_RAM_507
+	STA PPUScrollCheckLo
 
 loc_BANK0_85E7:
 	LDA #$00
@@ -1119,23 +1191,28 @@ loc_BANK0_85E7:
 
 
 ;
+; Applies horizontal screen scrolling.
+;
+; Unlike vertical scrolling, horizontal scrolling can happen continuously as
+; the player moves left and right.
 ;
 ;
-sub_BANK0_85EC:
-	; Reset this flag @TODO ;;;
+;
+ApplyHorizontalScroll:
+	; Reset the PPU tile update flag
 	LDA #$00
-	STA byte_RAM_51C
+	STA HasScrollingPPUTilesUpdate
 
 	; Are we scrolling in more tiles?
 	LDA HorizontalScrollDirection
-	BEQ loc_BANK0_862C
+	BEQ ApplyHorizontalScroll_CheckCameraVelocityX
 
 	; Which direction?
 	LDA HorizontalScrollDirection
 	LSR A
-	BCS loc_BANK0_8618
+	BCS ApplyHorizontalScroll_Left
 
-; right
+ApplyHorizontalScroll_Right:
 	LDX #$02
 	STX byte_RAM_9
 	LDA #$10
@@ -1143,51 +1220,50 @@ sub_BANK0_85EC:
 	DEX
 	LDA HorizontalScrollDirection
 	STA NeedsScroll
-	JSR sub_BANK0_8901
+	JSR CopyAttributesToHorizontalBuffer
 
 	LDA byte_RAM_3
-	STA byte_RAM_D0
+	STA BackgroundUpdateBoundaryForward
 	LDA #$00
 	STA HorizontalScrollDirection
-	BEQ loc_BANK0_862C
+	BEQ ApplyHorizontalScroll_CheckCameraVelocityX
 
-; left
-loc_BANK0_8618:
+ApplyHorizontalScroll_Left:
 	LDX #$01
 	STX byte_RAM_9
 	DEX
 	STX byte_RAM_1
 	LDA HorizontalScrollDirection
 	STA NeedsScroll
-	JSR sub_BANK0_8901
+	JSR CopyAttributesToHorizontalBuffer
 
 	LDA #$00
 	STA HorizontalScrollDirection
 
-loc_BANK0_862C:
+ApplyHorizontalScroll_CheckCameraVelocityX:
 	LDA CameraVelocityX
-	BNE loc_BANK0_8631
+	BNE ApplyCameraVelocityX
 
 	RTS
 
-; ---------------------------------------------------------------------------
 
-loc_BANK0_8631:
+ApplyCameraVelocityX:
 	LDA CameraVelocityX
-	BPL loc_BANK0_863C
+	BPL ApplyCameraVelocityX_Right
 
+ApplyCameraVelocityX_ScrollLeft:
 	LDA #$01
 	STA NeedsScroll
-	JMP loc_BANK0_869A
 
-; ---------------------------------------------------------------------------
+	; Weird `JMP`, but okay...
+	JMP ApplyCameraVelocityX_Left
 
-loc_BANK0_863C:
+ApplyCameraVelocityX_Right:
 	LDA #$02
 	STA NeedsScroll
-	LDX CameraVelocityX
 
-loc_BANK0_8642:
+	LDX CameraVelocityX
+ApplyCameraVelocityX_Right_Loop:
 	LDA PPUScrollXMirror
 	BNE loc_BANK0_8651
 
@@ -1195,10 +1271,12 @@ loc_BANK0_8642:
 	CMP CurrentLevelPages
 	BNE loc_BANK0_8651
 
-	JMP loc_BANK0_86E9
+	; Can't scroll past beyond the last page of the area
+	JMP ApplyCameraVelocityX_Exit
 
-; ---------------------------------------------------------------------------
-
+; Scrolling one pixel at a time in a tight loop seems crazy at first, but in
+; practice it only ends up being like 3 iterations at most.
+ApplyCameraVelocityX_Right_AddPixel:
 loc_BANK0_8651:
 	LDA PPUScrollXMirror
 	CLC
@@ -1222,48 +1300,44 @@ loc_BANK0_8669:
 	LDA PPUScrollXMirror
 	AND #$F0
 	CMP CurrentLevelPageX
-	BEQ loc_BANK0_8682
+	BEQ ApplyCameraVelocityX_Right_Next
 
 	STA CurrentLevelPageX
 	LDA #$01
-	STA byte_RAM_51C
+	STA HasScrollingPPUTilesUpdate
 
-loc_BANK0_8682:
+ApplyCameraVelocityX_Right_Next:
 	DEX
-	BNE loc_BANK0_8642
+	BNE ApplyCameraVelocityX_Right_Loop
 
 loc_BANK0_8685:
-	LDA byte_RAM_51C
-	BEQ loc_BANK0_86E9
+	LDA HasScrollingPPUTilesUpdate
+	BEQ ApplyCameraVelocityX_Exit
 
 	LDX #$02
-
 loc_BANK0_868C:
-	JSR loc_BANK0_87FC
+	JSR IncrementHorizontalScrollColumn
 
 	DEX
 	BNE loc_BANK0_868C
 
 	LDX #$02
-	JSR sub_BANK0_8812
+	JSR PrepareBackgroundDrawing_Horizontal
 
 	JMP loc_BANK0_86E6
 
-; ---------------------------------------------------------------------------
 
-loc_BANK0_869A:
+ApplyCameraVelocityX_Left:
 	LDX CameraVelocityX
-
-loc_BANK0_869C:
+ApplyCameraVelocityX_Left_Loop:
 	LDA PPUScrollXMirror
 	BNE loc_BANK0_86A8
 
 	LDA ScreenBoundaryLeftHi
 	BNE loc_BANK0_86A8
 
-	JMP loc_BANK0_86E9
-
-; ---------------------------------------------------------------------------
+	; Can't scroll past beyond the first page of the area
+	JMP ApplyCameraVelocityX_Exit
 
 loc_BANK0_86A8:
 	LDA PPUScrollXMirror
@@ -1288,35 +1362,32 @@ loc_BANK0_86C0:
 
 	STA CurrentLevelPageX
 	LDA #$01
-	STA byte_RAM_51C
+	STA HasScrollingPPUTilesUpdate
 
 loc_BANK0_86D1:
 	INX
-	BNE loc_BANK0_869C
+	BNE ApplyCameraVelocityX_Left_Loop
 
-	LDA byte_RAM_51C
-	BEQ loc_BANK0_86E9
+	LDA HasScrollingPPUTilesUpdate
+	BEQ ApplyCameraVelocityX_Exit
 
 	LDX #$02
-
 loc_BANK0_86DB:
-	JSR loc_BANK0_87E6
+	JSR DecrementHorizontalScrollColumn
 
 	DEX
 	BNE loc_BANK0_86DB
 
 	LDX #$01
-	JSR sub_BANK0_8812
+	JSR PrepareBackgroundDrawing_Horizontal
 
 loc_BANK0_86E6:
-	JSR sub_BANK0_8872
+	JSR CopyBackgroundToPPUBuffer_Horizontal
 
-loc_BANK0_86E9:
+ApplyCameraVelocityX_Exit:
 	LDA #$00
 	STA NeedsScroll
 	RTS
-
-; End of function sub_BANK0_85EC
 
 
 ;
@@ -1329,7 +1400,7 @@ loc_BANK0_86E9:
 ; ##### Output
 ; - `PPUScrollYHiMirror`
 ; - `PPUScrollXHiMirror`
-; - `byte_RAM_506`: PPU scroll offset high byte
+; - `PPUScrollCheckHi`: PPU scroll offset high byte
 ;
 ResetPPUScrollHi:
 	LSR A
@@ -1350,7 +1421,7 @@ ResetPPUScrollHi_NametableB:
 	LDA PPUScrollHiOffsets, Y
 
 ResetPPUScrollHi_Exit:
-	STA byte_RAM_506
+	STA PPUScrollCheckHi
 	RTS
 
 
@@ -1393,9 +1464,9 @@ UseSubareaScreenBoundaries:
 	JSR ApplyAreaTransition
 
 	LDA SubAreaPage
-	STA byte_RAM_CE
+	STA BackgroundUpdateBoundary
 	LDA #$E0
-	STA byte_RAM_506
+	STA PPUScrollCheckHi
 	LDA SubAreaPage
 	CLC
 	ADC #$F0
@@ -1420,29 +1491,30 @@ UseMainAreaScreenBoundaries:
 	INC byte_RAM_D5
 	JSR RestorePlayerPosition
 
-	LDA byte_RAM_CF
-	STA byte_RAM_CE
+	LDA BackgroundUpdateBoundaryBackward
+	STA BackgroundUpdateBoundary
 	LDA #$10
 	STA byte_RAM_1
 	LDA #$F0
-	STA byte_RAM_506
-	STA byte_RAM_507
-	LDA byte_RAM_D0
+	STA PPUScrollCheckHi
+	STA PPUScrollCheckLo
+	LDA BackgroundUpdateBoundaryForward
 	STA byte_RAM_505
 
 UseMainAreaScreenBoundaries_Exit:
 	RTS
 
+
 ; Used for redrawing the screen in a horizontal area after unpausing
 sub_BANK0_8785:
-	LDA byte_RAM_CF
-	STA byte_RAM_CE
+	LDA BackgroundUpdateBoundaryBackward
+	STA BackgroundUpdateBoundary
 	LDA #$10
 	STA byte_RAM_1
 	LDA #$F0
-	STA byte_RAM_506
-	STA byte_RAM_507
-	LDA byte_RAM_D0
+	STA PPUScrollCheckHi
+	STA PPUScrollCheckLo
+	LDA BackgroundUpdateBoundaryForward
 	CLC
 	ADC #$10
 	ADC #$00
@@ -1461,20 +1533,21 @@ loc_BANK0_87A2:
 sub_BANK0_87AA:
 	LDX #$00
 	STX byte_RAM_537
-	STX byte_RAM_51C
+	STX HasScrollingPPUTilesUpdate
 	STX NeedsScroll
-	JSR sub_BANK0_8812
 
-	JSR sub_BANK0_8872
+	JSR PrepareBackgroundDrawing_Horizontal
 
-	LDA byte_RAM_506
-	CMP byte_RAM_D1
+	JSR CopyBackgroundToPPUBuffer_Horizontal
+
+	LDA PPUScrollCheckHi
+	CMP DrawBackgroundTilesPPUAddrHi
 	BNE loc_BANK0_87DA
 
-	LDA byte_RAM_507
+	LDA PPUScrollCheckLo
 	CLC
 	ADC #$01
-	CMP byte_RAM_D2
+	CMP DrawBackgroundTilesPPUAddrLo
 	BNE loc_BANK0_87DA
 
 loc_BANK0_87CB:
@@ -1488,153 +1561,185 @@ loc_BANK0_87CB:
 ; ---------------------------------------------------------------------------
 
 loc_BANK0_87DA:
-	LDA byte_RAM_CE
+	LDA BackgroundUpdateBoundary
 	CMP byte_RAM_505
 	BEQ loc_BANK0_87CB
 
 	LDX #$00
-	JMP loc_BANK0_87FC
+	JMP IncrementHorizontalScrollColumn
 
-; ---------------------------------------------------------------------------
-
-loc_BANK0_87E6:
-	LDA byte_RAM_CE, X
+;
+; Decrement the drawing boundary table entry by one column of tiles
+;
+DecrementHorizontalScrollColumn:
+	; Decrement the column offset
+	LDA BackgroundUpdateBoundary, X
 	SEC
 	SBC #$10
-	STA byte_RAM_CE, X
-	BCS locret_BANK0_87FB
+	STA BackgroundUpdateBoundary, X
+	BCS DecrementHorizontalScrollColumn_Exit
 
-	DEC byte_RAM_CE, X
-	LDA byte_RAM_CE, X
-	CMP #$0EF
-	BNE locret_BANK0_87FB
+	; Decrement the page
+	DEC BackgroundUpdateBoundary, X
+	LDA BackgroundUpdateBoundary, X
+	CMP #$EF
+	BNE DecrementHorizontalScrollColumn_Exit
 
+	; Wrap around to the last column of the last page
 	LDA #$F9
-	STA byte_RAM_CE, X
+	STA BackgroundUpdateBoundary, X
 
-locret_BANK0_87FB:
+DecrementHorizontalScrollColumn_Exit:
 	RTS
 
-; ---------------------------------------------------------------------------
 
-loc_BANK0_87FC:
-	LDA byte_RAM_CE, X
+;
+; Increment the drawing boundary table entry by one column of tiles
+;
+IncrementHorizontalScrollColumn:
+	; Increment the column offset
+	LDA BackgroundUpdateBoundary, X
 	CLC
 	ADC #$10
-	STA byte_RAM_CE, X
-	BCC locret_BANK0_8811
+	STA BackgroundUpdateBoundary, X
+	BCC IncrementHorizontalScrollColumn_Exit
 
-	INC byte_RAM_CE, X
-	LDA byte_RAM_CE, X
+	; Increment the page
+	INC BackgroundUpdateBoundary, X
+	LDA BackgroundUpdateBoundary, X
 	CMP #$0A
-	BNE locret_BANK0_8811
+	BNE IncrementHorizontalScrollColumn_Exit
 
+	; Wrap around to the first page
 	LDA #$00
-	STA byte_RAM_CE, X
+	STA BackgroundUpdateBoundary, X
 
-locret_BANK0_8811:
+IncrementHorizontalScrollColumn_Exit:
 	RTS
 
-; End of function sub_BANK0_87AA
 
-; =============== S U B R O U T I N E =======================================
-
-sub_BANK0_8812:
+;
+; Determines which background tiles from the decoded level data to draw to the
+; screen and where to draw them for horizontal areas.
+;
+; ##### Input
+; - `BackgroundUpdateBoundary`: drawing boundary table
+; - `X`: drawing boundary index (`$00` = full, `$01` = left, `$02` = right)
+;
+; ##### Output
+; - `ReadLevelDataAddress`: decoded level data address
+; - `ReadLevelDataOffset`: level data offset
+; - `DrawBackgroundTilesPPUAddrHi`/`DrawBackgroundTilesPPUAddrLo`: PPU start address
+;
+PrepareBackgroundDrawing_Horizontal:
+	; Stash Y so we can restore it later
 	STY byte_RAM_F
-	LDA byte_RAM_CE, X
+
+	; Lower nybble is used for page
+	LDA BackgroundUpdateBoundary, X
 	AND #$0F
 	TAY
+	; Get the address of the decoded level data
 	LDA DecodedLevelPageStartLo_Bank1, Y
-	STA byte_RAM_E9
+	STA ReadLevelDataAddress
 	LDA DecodedLevelPageStartHi_Bank1, Y
-	STA byte_RAM_EA
-	LDA byte_RAM_CE, X
+	STA ReadLevelDataAddress + 1
+
+	; Upper nybble is used for the tile offset (columns)
+	LDA BackgroundUpdateBoundary, X
 	LSR A
 	LSR A
 	LSR A
 	LSR A
-	STA byte_RAM_D7
+	STA ReadLevelDataOffset
+
+	; Determine where on the screen we should draw the tile
 	ASL A
-	STA byte_RAM_D2
+	STA DrawBackgroundTilesPPUAddrLo
+
 	LDY #$20
-	LDA byte_RAM_CE, X
+	LDA BackgroundUpdateBoundary, X
 	LSR A
-	BCS loc_BANK0_8837
+	BCS PrepareBackgroundDrawing_Horizontal_Exit
 
 	LDY #$24
 
-loc_BANK0_8837:
-	STY byte_RAM_D1
+PrepareBackgroundDrawing_Horizontal_Exit:
+	STY DrawBackgroundTilesPPUAddrHi
+
+	; Restore original Y value
 	LDY byte_RAM_F
+
 	RTS
 
-; End of function sub_BANK0_8812
 
-; =============== S U B R O U T I N E =======================================
-
+;
+; horizontal
+;
 sub_BANK0_883C:
 	STX byte_RAM_8
 	LDX byte_RAM_9
 	LDY #$02
-	LDA byte_RAM_CE, X
+	LDA BackgroundUpdateBoundary, X
 	STA byte_RAM_3
 	SEC
 	SBC byte_RAM_1
-	STA byte_RAM_CE, X
-	JSR sub_BANK0_8812
+	STA BackgroundUpdateBoundary, X
+
+	JSR PrepareBackgroundDrawing_Horizontal
 
 	LDA #$07
-	STA byte_RAM_E3
+	STA PPUAttributeUpdateCounter
 	LDA #$00
-	STA byte_RAM_D6
+	STA CopyBackgroundCounter
 
 loc_BANK0_8856:
 	JSR sub_BANK0_8925
 
-	LDA byte_RAM_E3
+	LDA PPUAttributeUpdateCounter
 	BPL loc_BANK0_8856
 
-	LDA byte_RAM_D2
+	LDA DrawBackgroundTilesPPUAddrLo
 	AND #$1C
 	LSR A
 	LSR A
 	ORA #$C0
-	STA byte_RAM_3BD
-	LDA byte_RAM_D1
+	STA DrawBackgroundAttributesPPUAddrLo
+	LDA DrawBackgroundTilesPPUAddrHi
 	ORA #$03
-	STA byte_RAM_3BC
+	STA DrawBackgroundAttributesPPUAddrHi
 	LDX byte_RAM_8
 	RTS
 
-; End of function sub_BANK0_883C
 
-; =============== S U B R O U T I N E =======================================
-
-sub_BANK0_8872:
+;
+; Draws the background data to the PPU buffer
+;
+CopyBackgroundToPPUBuffer_Horizontal:
 	LDA #$0F
-	STA byte_RAM_E3
+	STA PPUAttributeUpdateCounter
+
 	LDA #$00
-	STA byte_RAM_D6
+	STA CopyBackgroundCounter
 	STA byte_RAM_D5
 	TAX
-
-loc_BANK0_887D:
-	LDY byte_RAM_D7
-	LDA (byte_RAM_E9), Y
-	STA byte_RAM_51B
-	AND #$C0
+CopyBackgroundToPPUBuffer_Horizontal_Loop:
+	LDY ReadLevelDataOffset
+	LDA (ReadLevelDataAddress), Y
+	STA DrawTileId
+	AND #%11000000
 	ASL A
 	ROL A
 	ROL A
 	TAY
+	; Get the tile quad pointer
 	LDA TileQuadPointersLo, Y
 	STA byte_RAM_0
 	LDA TileQuadPointersHi, Y
 	STA byte_RAM_1
 
-loc_BANK0_8894:
-	LDY byte_RAM_D7
-	LDA (byte_RAM_E9), Y
+	LDY ReadLevelDataOffset
+	LDA (ReadLevelDataAddress), Y
 	ASL A
 	ASL A
 	TAY
@@ -1645,7 +1750,7 @@ loc_BANK0_8894:
 
 loc_BANK0_88A0:
 	LDA (byte_RAM_0), Y
-	STA unk_RAM_380, X
+	STA ScrollingPPUTileUpdateBuffer, X
 	INY
 	LDA (byte_RAM_0), Y
 	STA unk_RAM_39E, X
@@ -1655,24 +1760,25 @@ loc_BANK0_88A0:
 	INY
 	LDA (byte_RAM_0), Y
 	STA unk_RAM_39F, X
-	INC byte_RAM_D6
+	INC CopyBackgroundCounter
 	INX
 	INX
-	LDA byte_RAM_D7
+	LDA ReadLevelDataOffset
 	CLC
 	ADC #$10
-	STA byte_RAM_D7
-	LDA byte_RAM_D6
+	STA ReadLevelDataOffset
+	LDA CopyBackgroundCounter
 	CMP #$0F
-	BCC loc_BANK0_887D
+	BCC CopyBackgroundToPPUBuffer_Horizontal_Loop
 
 	LDA #$00
-	STA byte_RAM_3BC
+	STA DrawBackgroundAttributesPPUAddrHi
 	LDA NeedsScroll
 	LSR A
 	BCS loc_BANK0_88F2
 
-	LDA byte_RAM_D2
+; down
+	LDA DrawBackgroundTilesPPUAddrLo
 	AND #$02
 	BEQ loc_BANK0_88FD
 
@@ -1684,18 +1790,17 @@ loc_BANK0_88A0:
 	LDX #$00
 	STX byte_RAM_9
 	INX
-	JSR sub_BANK0_8901
+	JSR CopyAttributesToHorizontalBuffer
 
 	LDA byte_RAM_3
-	STA byte_RAM_CE
-	JSR sub_BANK0_8812
+	STA BackgroundUpdateBoundary
+	JSR PrepareBackgroundDrawing_Horizontal
 
 	JMP loc_BANK0_88FD
 
-; ---------------------------------------------------------------------------
-
+; up
 loc_BANK0_88F2:
-	LDA byte_RAM_D2
+	LDA DrawBackgroundTilesPPUAddrLo
 	AND #$02
 	BNE loc_BANK0_88FD
 
@@ -1704,81 +1809,85 @@ loc_BANK0_88F8:
 	STA HorizontalScrollDirection
 
 loc_BANK0_88FD:
-	INC byte_RAM_51C
+	INC HasScrollingPPUTilesUpdate
 	RTS
 
-; End of function sub_BANK0_8872
 
-; =============== S U B R O U T I N E =======================================
-
-sub_BANK0_8901:
+;
+; Does some kind of transformation to copy PPU attribute data from the common
+; scrolling PPU update buffer to the horizontal-only buffer.
+;
+; I'm not totally sure why it is necessary to do this rather than writing the
+; attribute data in the final order the first time?
+;
+; NOTE: There is code that assumes `X = $00` after running this subroutine!
+;
+CopyAttributesToHorizontalBuffer:
 	JSR sub_BANK0_883C
 
 	LDX #$07
 	STX byte_RAM_E
 	LDY #$00
-
-loc_BANK0_890A:
+CopyAttributesToHorizontalBuffer_Loop:
 	LDX byte_RAM_E
-	LDA EnemyArray_D9, X
-	STA unk_RAM_3BE, Y
+	LDA ScrollingPPUAttributeUpdateBuffer, X
+	STA HorizontalScrollingPPUAttributeUpdateBuffer, Y
 	INY
 	DEX
 	DEX
 	DEX
 	DEX
-	LDA EnemyArray_D9, X
-	STA unk_RAM_3BE, Y
+	LDA ScrollingPPUAttributeUpdateBuffer, X
+	STA HorizontalScrollingPPUAttributeUpdateBuffer, Y
 	INY
 	DEC byte_RAM_E
 	LDA byte_RAM_E
 	CMP #03
-	BNE loc_BANK0_890A
+	BNE CopyAttributesToHorizontalBuffer_Loop
 
 	RTS
 
-; End of function sub_BANK0_8901
 
-; =============== S U B R O U T I N E =======================================
-
+;
+; Determines the PPU attribute data for a group of four tiles in a horizontal area.
+; Reads a group of four background tiles to determine the PPU attribute data
+;
 sub_BANK0_8925:
 	STY byte_RAM_F
 	LDA #01
 	STA byte_RAM_4
-	LDY byte_RAM_D7
-	LDX byte_RAM_E3
+	LDY ReadLevelDataOffset
+	LDX PPUAttributeUpdateCounter
 
 loc_BANK0_892F:
-	LDA EnemyArray_D9, X
+	LDA ScrollingPPUAttributeUpdateBuffer, X
 	LSR A
 	LSR A
-	STA EnemyArray_D9, X
-	LDA (byte_RAM_E9), Y
-	AND #$C0
-	ORA EnemyArray_D9, X
-	STA EnemyArray_D9, X
+	STA ScrollingPPUAttributeUpdateBuffer, X
+	LDA (ReadLevelDataAddress), Y
+	AND #%11000000
+	ORA ScrollingPPUAttributeUpdateBuffer, X
+	STA ScrollingPPUAttributeUpdateBuffer, X
 	INY
-	LDA EnemyArray_D9, X
+	LDA ScrollingPPUAttributeUpdateBuffer, X
 	LSR A
 	LSR A
-	STA EnemyArray_D9, X
-	LDA (byte_RAM_E9), Y
-	AND #$C0
-	ORA EnemyArray_D9, X
-	STA EnemyArray_D9, X
-	LDA byte_RAM_D7
+	STA ScrollingPPUAttributeUpdateBuffer, X
+	LDA (ReadLevelDataAddress), Y
+	AND #%11000000
+	ORA ScrollingPPUAttributeUpdateBuffer, X
+	STA ScrollingPPUAttributeUpdateBuffer, X
+	LDA ReadLevelDataOffset
 	CLC
 	ADC #$10
 	TAY
-	STA byte_RAM_D7
+	STA ReadLevelDataOffset
 	DEC byte_RAM_4
 	BPL loc_BANK0_892F
 
-	DEC byte_RAM_E3
+	DEC PPUAttributeUpdateCounter
 	LDY byte_RAM_F
 	RTS
-
-; End of function sub_BANK0_8925
 
 
 SetObjectLocks:
@@ -3932,7 +4041,7 @@ byte_BANK0_92E0:
 
 
 ; Unused?
-; Copy of StartVerticalScroll
+; Copy of DetermineVerticalScroll
 _code_12E3:
 	LDX NeedsScroll
 	BNE locret_BANK0_9311
@@ -4491,7 +4600,7 @@ AreaTransitionPlacement_DoorCustom:
 	JSR SetAreaPageAddr_Bank1
 
 	; Start at the bottom right and work backwards
-	LDA #$0EF
+	LDA #$EF
 	STA byte_RAM_E7
 
 AreaTransitionPlacement_DoorCustom_Loop:
@@ -4794,15 +4903,9 @@ TitleScreenPPUDataPointers:
 	.dw TitleLayout
 
 
-; =============== S U B R O U T I N E =======================================
-
 WaitForNMI_TitleScreen_TurnOnPPU:
 	LDA #PPUMask_ShowLeft8Pixels_BG | PPUMask_ShowLeft8Pixels_SPR | PPUMask_ShowBackground | PPUMask_ShowSprites
 	STA PPUMaskMirror
-
-; End of function WaitForNMI_TitleScreen_TurnOnPPU
-
-; =============== S U B R O U T I N E =======================================
 
 WaitForNMI_TitleScreen:
 	LDA ScreenUpdateIndex
@@ -4812,16 +4915,14 @@ WaitForNMI_TitleScreen:
 	STA RAM_PPUDataBufferPointer
 	LDA TitleScreenPPUDataPointers + 1, X
 	STA RAM_PPUDataBufferPointer + 1
+
 	LDA #$00
 	STA NMIWaitFlag
-
 WaitForNMI_TitleScreenLoop:
 	LDA NMIWaitFlag
 	BPL WaitForNMI_TitleScreenLoop
 
 	RTS
-
-; End of function WaitForNMI_TitleScreen
 
 
 TitleLayout:
@@ -5123,12 +5224,12 @@ InitMemoryLoop2:
 	STA PPUADDR
 	STY PPUADDR
 
-loc_BANK0_9A6F:
+InitTitleBackgroundPalettesLoop:
 	LDA TitleBackgroundPalettes, Y
 	STA PPUDATA
 	INY
 	CPY #$20
-	BCC loc_BANK0_9A6F
+	BCC InitTitleBackgroundPalettesLoop
 
 	LDA #$01
 	STA RAM_PPUDataBufferPointer

--- a/src/prg-0-1.asm
+++ b/src/prg-0-1.asm
@@ -1095,7 +1095,7 @@ sub_BANK0_856A:
 	LDA CurrentLevelEntryPage
 	BNE loc_BANK0_8576
 
-	LDA CameraVelocityX
+	LDA MoveCameraX
 	BMI loc_BANK0_85E7
 
 	LDA CurrentLevelEntryPage
@@ -1104,12 +1104,12 @@ loc_BANK0_8576:
 	CMP CurrentLevelPages
 	BNE loc_BANK0_857F
 
-	LDA CameraVelocityX
+	LDA MoveCameraX
 	BPL loc_BANK0_85E7
 
 loc_BANK0_857F:
 	LDX #$02
-	LDA CameraVelocityX
+	LDA MoveCameraX
 	BPL loc_BANK0_858B
 
 	LDA #$FF
@@ -1121,7 +1121,7 @@ loc_BANK0_858B:
 	STA byte_RAM_B
 
 loc_BANK0_858F:
-	LDA CameraVelocityX
+	LDA MoveCameraX
 	AND #$F0
 	CLC
 	ADC BackgroundUpdateBoundary, X
@@ -1167,12 +1167,12 @@ loc_BANK0_85C4:
 	DEX
 	BPL loc_BANK0_858F
 
-	LDA CameraVelocityX
+	LDA MoveCameraX
 	STA PPUScrollXMirror
 	STA ScreenBoundaryLeftLo
 	AND #$F0
 	STA CurrentLevelPageX
-	LDA CameraVelocityX
+	LDA MoveCameraX
 	BPL loc_BANK0_85E7
 
 	DEC ScreenBoundaryLeftHi
@@ -1184,7 +1184,7 @@ loc_BANK0_85C4:
 
 loc_BANK0_85E7:
 	LDA #$00
-	STA CameraVelocityX
+	STA MoveCameraX
 	RTS
 
 ; End of function sub_BANK0_856A
@@ -1205,7 +1205,7 @@ ApplyHorizontalScroll:
 
 	; Are we scrolling in more tiles?
 	LDA HorizontalScrollDirection
-	BEQ ApplyHorizontalScroll_CheckCameraVelocityX
+	BEQ ApplyHorizontalScroll_CheckMoveCameraX
 
 	; Which direction?
 	LDA HorizontalScrollDirection
@@ -1226,7 +1226,7 @@ ApplyHorizontalScroll_Right:
 	STA BackgroundUpdateBoundaryForward
 	LDA #$00
 	STA HorizontalScrollDirection
-	BEQ ApplyHorizontalScroll_CheckCameraVelocityX
+	BEQ ApplyHorizontalScroll_CheckMoveCameraX
 
 ApplyHorizontalScroll_Left:
 	LDX #$01
@@ -1240,30 +1240,30 @@ ApplyHorizontalScroll_Left:
 	LDA #$00
 	STA HorizontalScrollDirection
 
-ApplyHorizontalScroll_CheckCameraVelocityX:
-	LDA CameraVelocityX
-	BNE ApplyCameraVelocityX
+ApplyHorizontalScroll_CheckMoveCameraX:
+	LDA MoveCameraX
+	BNE ApplyMoveCameraX
 
 	RTS
 
 
-ApplyCameraVelocityX:
-	LDA CameraVelocityX
-	BPL ApplyCameraVelocityX_Right
+ApplyMoveCameraX:
+	LDA MoveCameraX
+	BPL ApplyMoveCameraX_Right
 
-ApplyCameraVelocityX_ScrollLeft:
+ApplyMoveCameraX_ScrollLeft:
 	LDA #$01
 	STA NeedsScroll
 
 	; Weird `JMP`, but okay...
-	JMP ApplyCameraVelocityX_Left
+	JMP ApplyMoveCameraX_Left
 
-ApplyCameraVelocityX_Right:
+ApplyMoveCameraX_Right:
 	LDA #$02
 	STA NeedsScroll
 
-	LDX CameraVelocityX
-ApplyCameraVelocityX_Right_Loop:
+	LDX MoveCameraX
+ApplyMoveCameraX_Right_Loop:
 	LDA PPUScrollXMirror
 	BNE loc_BANK0_8651
 
@@ -1272,11 +1272,11 @@ ApplyCameraVelocityX_Right_Loop:
 	BNE loc_BANK0_8651
 
 	; Can't scroll past beyond the last page of the area
-	JMP ApplyCameraVelocityX_Exit
+	JMP ApplyMoveCameraX_Exit
 
 ; Scrolling one pixel at a time in a tight loop seems crazy at first, but in
 ; practice it only ends up being like 3 iterations at most.
-ApplyCameraVelocityX_Right_AddPixel:
+ApplyMoveCameraX_Right_AddPixel:
 loc_BANK0_8651:
 	LDA PPUScrollXMirror
 	CLC
@@ -1300,19 +1300,19 @@ loc_BANK0_8669:
 	LDA PPUScrollXMirror
 	AND #$F0
 	CMP CurrentLevelPageX
-	BEQ ApplyCameraVelocityX_Right_Next
+	BEQ ApplyMoveCameraX_Right_Next
 
 	STA CurrentLevelPageX
 	LDA #$01
 	STA HasScrollingPPUTilesUpdate
 
-ApplyCameraVelocityX_Right_Next:
+ApplyMoveCameraX_Right_Next:
 	DEX
-	BNE ApplyCameraVelocityX_Right_Loop
+	BNE ApplyMoveCameraX_Right_Loop
 
 loc_BANK0_8685:
 	LDA HasScrollingPPUTilesUpdate
-	BEQ ApplyCameraVelocityX_Exit
+	BEQ ApplyMoveCameraX_Exit
 
 	LDX #$02
 loc_BANK0_868C:
@@ -1327,9 +1327,9 @@ loc_BANK0_868C:
 	JMP loc_BANK0_86E6
 
 
-ApplyCameraVelocityX_Left:
-	LDX CameraVelocityX
-ApplyCameraVelocityX_Left_Loop:
+ApplyMoveCameraX_Left:
+	LDX MoveCameraX
+ApplyMoveCameraX_Left_Loop:
 	LDA PPUScrollXMirror
 	BNE loc_BANK0_86A8
 
@@ -1337,7 +1337,7 @@ ApplyCameraVelocityX_Left_Loop:
 	BNE loc_BANK0_86A8
 
 	; Can't scroll past beyond the first page of the area
-	JMP ApplyCameraVelocityX_Exit
+	JMP ApplyMoveCameraX_Exit
 
 loc_BANK0_86A8:
 	LDA PPUScrollXMirror
@@ -1366,10 +1366,10 @@ loc_BANK0_86C0:
 
 loc_BANK0_86D1:
 	INX
-	BNE ApplyCameraVelocityX_Left_Loop
+	BNE ApplyMoveCameraX_Left_Loop
 
 	LDA HasScrollingPPUTilesUpdate
-	BEQ ApplyCameraVelocityX_Exit
+	BEQ ApplyMoveCameraX_Exit
 
 	LDX #$02
 loc_BANK0_86DB:
@@ -1384,7 +1384,7 @@ loc_BANK0_86DB:
 loc_BANK0_86E6:
 	JSR CopyBackgroundToPPUBuffer_Horizontal
 
-ApplyCameraVelocityX_Exit:
+ApplyMoveCameraX_Exit:
 	LDA #$00
 	STA NeedsScroll
 	RTS
@@ -4418,7 +4418,7 @@ ApplyAreaTransition_MoveCamera:
 	LDA PlayerXLo
 	SEC
 	SBC #$78
-	STA CameraVelocityX
+	STA MoveCameraX
 	RTS
 
 
@@ -4830,7 +4830,7 @@ ENDIF
 AreaTransitionPlacement_Subspace:
 	LDA PlayerScreenX
 	SEC
-	SBC CameraVelocityX
+	SBC MoveCameraX
 	EOR #$FF
 	CLC
 	ADC #$F1

--- a/src/prg-0-1.asm
+++ b/src/prg-0-1.asm
@@ -2011,7 +2011,7 @@ loc_BANK0_8ADF:
 	CMP #$08
 	BCS loc_BANK0_8B14
 
-	LDY byte_BANKF_F00B
+	LDY TileCollisionHitboxIndex + $0B
 	LDA PlayerYVelocity
 	BMI loc_BANK0_8B01
 
@@ -2681,8 +2681,8 @@ SoftThrowOffset:
 	.db $10
 
 
-; =============== S U B R O U T I N E =======================================
 
+; Determine the max speed based on the terrain and what the player is carrying.
 sub_BANK0_8DC0:
 	LDY #$02
 	LDA QuicksandDepth
@@ -2707,6 +2707,7 @@ sub_BANK0_8DC0:
 loc_BANK0_8DDF:
 	DEY
 
+; 1.5x max speed when the run button is held!
 loc_BANK0_8DE0:
 	LDA RunSpeedRight, Y
 	BIT Player1JoypadHeld
@@ -2738,6 +2739,7 @@ loc_BANK0_8DFF:
 
 	STA PlayerXVelocity
 
+; Check to see if we have an item that we want to throw.
 loc_BANK0_8E05:
 	BIT Player1JoypadPress
 	BVC locret_BANK0_8E41
@@ -2770,7 +2772,7 @@ loc_BANK0_8E28:
 	ASL A
 	ORA PlayerDucking
 	TAX
-	LDY byte_BANKF_F006, X
+	LDY TileCollisionHitboxIndex + $06, X
 	LDX #$00
 	JSR sub_BANK0_924F
 
@@ -2995,7 +2997,7 @@ PlayerTileCollision:
 	TAX
 
 	; Look up the bounding box for collision detection
-	LDA byte_BANKF_F000, X
+	LDA TileCollisionHitboxIndex, X
 	STA byte_RAM_8
 
 	; Determine whether the player is going up
@@ -3267,11 +3269,11 @@ CheckPlayerTileCollision_Increment:
 
 
 PlayerTileCollision_CheckCherryAndClimbable:
-	LDY byte_BANKF_F00A
+	LDY TileCollisionHitboxIndex + $0A
 
 	; byte_RAM_10 seems to be a global counter
 	; this code increments Y every other frame, but why?
-	; Seems like it alternates between doing the check on the left or right side each frame.
+	; Seems like it alternates on each frame between checking the top and bottom of the player.
 	LDA byte_RAM_10
 	LSR A
 	BCS PlayerTileCollision_CheckCherryAndClimbable_AfterTick
@@ -3785,7 +3787,7 @@ DoorTiles:
 ;
 ; Input
 ;   X = object index (0 = player)
-;   Y = bounding box offset?
+;   Y = bounding box offset
 ; Output
 ;   byte_RAM_0 = tile ID
 ;

--- a/src/prg-2-3.asm
+++ b/src/prg-2-3.asm
@@ -2640,9 +2640,9 @@ EnemyInit_Hawkmouth:
 	DEC ObjectYLo, X
 	DEC ObjectYLo, X
 	LDY #$01
-	STY byte_RAM_711F
+	STY ObjectCollisionHitboxTop_RAM + $0B
 	INY
-	STY byte_RAM_710B
+	STY ObjectCollisionHitboxLeft_RAM + $0B
 
 
 EnemyInit_Stationary:
@@ -2724,8 +2724,8 @@ loc_BANK2_8DBA:
 	AND #$03
 	BNE loc_BANK2_8DD8
 
-	DEC byte_RAM_711F
-	INC byte_RAM_710B
+	DEC ObjectCollisionHitboxTop_RAM + $0B
+	INC ObjectCollisionHitboxLeft_RAM + $0B
 
 loc_BANK2_8DD8:
 	JMP RenderSprite_HawkmouthLeft
@@ -10215,7 +10215,7 @@ ClearDirectionalCollisionFlags:
 	AND #CollisionFlags_Damage | CollisionFlags_PlayerOnTop | CollisionFlags_PlayerInsideMaybe | CollisionFlags_80
 	STA EnemyCollision - 1, X
 	LDY EnemyArray_492 - 1, X
-	LDA byte_BANKF_F000, Y
+	LDA TileCollisionHitboxIndex, Y
 
 ClearDirectionalCollisionFlags_Exit:
 	RTS
@@ -10270,14 +10270,14 @@ sub_BANK3_B5CC:
 	BNE loc_BANK3_B5FF
 
 loc_BANK3_B5E1:
-	CMP #$07
+	CMP #EnemyState_Sinking
 	BEQ loc_BANK3_B5F8
 
 	LDY ObjectType, X
 	CPY #Enemy_Egg
 	BEQ loc_BANK3_B5F4
 
-	CPY #$1A
+	CPY #Enemy_Pokey
 	BEQ loc_BANK3_B5F4
 
 	LDY EnemyArray_42F, X
@@ -10294,11 +10294,11 @@ loc_BANK3_B5F8:
 	LDY EnemyArray_489, X
 
 loc_BANK3_B5FF:
-	LDA unk_RAM_7128, Y
+	LDA ObjectCollisionHitboxRight_RAM, Y
 	STA byte_RAM_9
 	LDA #$00
 	STA byte_RAM_0
-	LDA unk_RAM_7100, Y
+	LDA ObjectCollisionHitboxLeft_RAM, Y
 	BPL loc_BANK3_B60F
 
 	DEC byte_RAM_0
@@ -10316,11 +10316,11 @@ loc_BANK3_B60F:
 	STA byte_RAM_1
 
 loc_BANK3_B620:
-	LDA unk_RAM_713C, Y
+	LDA ObjectCollisionHitboxBottom_RAM, Y
 	STA byte_RAM_B
 	LDA #$00
 	STA byte_RAM_0
-	LDA unk_RAM_7114, Y
+	LDA ObjectCollisionHitboxTop_RAM, Y
 	BPL loc_BANK3_B630
 
 	DEC byte_RAM_0
@@ -10368,7 +10368,7 @@ loc_BANK3_B65C:
 loc_BANK3_B661:
 	LDY byte_RAM_12
 	LDA EnemyState, Y
-	CMP #$04
+	CMP #EnemyState_BombExploding
 	BEQ loc_BANK3_B671
 
 	LDA EnemyArray_46E, Y
@@ -10384,14 +10384,14 @@ loc_BANK3_B671:
 	BNE loc_BANK3_B6A6
 
 loc_BANK3_B67B:
-	CMP #$07
+	CMP #EnemyState_Sinking
 	BEQ loc_BANK3_B692
 
 	LDY ObjectType - 1, X
 	CPY #Enemy_Egg
 	BEQ loc_BANK3_B68E
 
-	CPY #$1A
+	CPY #Enemy_Pokey
 	BEQ loc_BANK3_B68E
 
 	LDY EnemyArray_42F - 1, X
@@ -10418,11 +10418,11 @@ loc_BANK3_B692:
 	LDY EnemyArray_489 - 1, X
 
 loc_BANK3_B6A6:
-	LDA unk_RAM_7128, Y
+	LDA ObjectCollisionHitboxRight_RAM, Y
 	STA byte_RAM_A
 	LDA #$00
 	STA byte_RAM_0
-	LDA unk_RAM_7100, Y
+	LDA ObjectCollisionHitboxLeft_RAM, Y
 	BPL loc_BANK3_B6B6
 
 	DEC byte_RAM_0
@@ -10440,11 +10440,11 @@ loc_BANK3_B6B6:
 	STA byte_RAM_2
 
 loc_BANK3_B6C7:
-	LDA unk_RAM_713C, Y
+	LDA ObjectCollisionHitboxBottom_RAM, Y
 	STA byte_RAM_C
 	LDA #$00
 	STA byte_RAM_0
-	LDA unk_RAM_7114, Y
+	LDA ObjectCollisionHitboxTop_RAM, Y
 	BPL loc_BANK3_B6D7
 
 	DEC byte_RAM_0

--- a/src/prg-2-3.asm
+++ b/src/prg-2-3.asm
@@ -251,7 +251,7 @@ AreaInitialization_HorizontalArea:
 
 loc_BANK2_8158:
 	LDA byte_RAM_6
-	CMP #$B
+	CMP #$0B
 	BCS loc_BANK2_8164
 
 	JSR sub_BANK2_827D

--- a/src/prg-2-3.asm
+++ b/src/prg-2-3.asm
@@ -122,7 +122,7 @@ AreaInitialization_CheckObjectCarriedOver:
 	LDY #EnemyState_Alive
 	STY EnemyState + 5
 	LDY #$FF
-	STY unk_RAM_441 + 5
+	STY EnemyRawDataOffset + 5
 	CMP #Enemy_Rocket
 	BNE AreaInitialization_NonRocketCarryOver
 
@@ -749,7 +749,7 @@ loc_BANK2_8393:
 loc_BANK2_83A6:
 	STA ObjectType, X
 	TYA
-	STA unk_RAM_441, X
+	STA EnemyRawDataOffset, X
 	INC EnemyState, X
 	LDA ObjectType, X
 
@@ -1064,7 +1064,7 @@ EnemyDeathMaybe:
 ;
 UnlinkEnemyFromRawData:
 	LDA #$FF
-	STA unk_RAM_441, X
+	STA EnemyRawDataOffset, X
 	RTS
 
 
@@ -1897,7 +1897,7 @@ loc_BANK2_89A5:
 
 EnemyDestroy:
 	; load raw enemy data offset so we can allow the level object to respawn
-	LDY unk_RAM_441, X
+	LDY EnemyRawDataOffset, X
 	; nothing to reset if offset is invalid
 	BMI EnemyDestroy_AfterAllowRespawn
 
@@ -7548,10 +7548,10 @@ EnemyBehavior_Ostro:
 	STA ObjectXLo, Y
 	LDA ObjectXHi, X
 	STA ObjectXHi, Y
-	LDA unk_RAM_441, X
-	STA unk_RAM_441, Y
+	LDA EnemyRawDataOffset, X
+	STA EnemyRawDataOffset, Y
 	LDA #$FF
-	STA unk_RAM_441, X
+	STA EnemyRawDataOffset, X
 	LDA ObjectXVelocity, X
 	STA ObjectXVelocity, Y
 	TYA
@@ -8276,10 +8276,10 @@ sub_BANK3_AA3E:
 	STA EnemyVariable, X
 	LDA #$02
 	STA EnemyArray_489, X
-	LDA unk_RAM_441, X
+	LDA EnemyRawDataOffset, X
 	STA byte_RAM_6
 	LDA #$FF
-	STA unk_RAM_441, X
+	STA EnemyRawDataOffset, X
 	JSR CreateEnemy
 
 	BMI loc_BANK3_AA99
@@ -8291,7 +8291,7 @@ sub_BANK3_AA3E:
 
 	LDY byte_RAM_0
 	LDA byte_RAM_6
-	STA unk_RAM_441, Y
+	STA EnemyRawDataOffset, Y
 	LDA EnemyArray_477, X
 	SEC
 	SBC #$01
@@ -8889,17 +8889,17 @@ EnemyBehavior_Autobomb:
 	STA ObjectType, X
 	JSR SetEnemyAttributes
 
-	LDA unk_RAM_441, X
+	LDA EnemyRawDataOffset, X
 	STA byte_RAM_6
 	LDA #$FF
-	STA unk_RAM_441, X
+	STA EnemyRawDataOffset, X
 	JSR CreateEnemy
 
 	BMI loc_BANK3_ADF9
 
 	LDY byte_RAM_0
 	LDA byte_RAM_6
-	STA unk_RAM_441, Y
+	STA EnemyRawDataOffset, Y
 	LDA ObjectXLo, X
 	STA ObjectXLo, Y
 	LDA ObjectXHi, X

--- a/src/prg-6-7.asm
+++ b/src/prg-6-7.asm
@@ -10,6 +10,16 @@
 ;   - Level handling code
 ;
 
+;
+; ## Level palettes
+;
+; Each world has several sets of background and sprite palettes, which are set per area in the level
+; header. Subspace is defined separately in each world, but they all use the same colors!
+;
+
+;
+; #### Palette pointers
+;
 WorldBackgroundPalettePointersLo:
 	.db <World1BackgroundPalettes
 	.db <World2BackgroundPalettes
@@ -46,6 +56,8 @@ WorldSpritePalettePointersHi:
 	.db >World6SpritePalettes
 	.db >World7SpritePalettes
 
+; #### World 1
+;
 World1BackgroundPalettes:
 	; Day
 	.db $21, $30, $12, $0F ; $00
@@ -100,6 +112,9 @@ IFDEF EXPAND_TABLES
 	unusedSpace World1SpritePalettes + $30, $FF
 ENDIF
 
+;
+; #### World 2
+;
 World2BackgroundPalettes:
 	; Day
 	.db $11, $30, $2A, $0F ; $00
@@ -154,6 +169,9 @@ IFDEF EXPAND_TABLES
 	unusedSpace World2SpritePalettes + $30, $FF
 ENDIF
 
+;
+; #### World 3
+;
 World3BackgroundPalettes:
 	; Day
 	.db $22, $30, $12, $0F ; $00
@@ -208,6 +226,9 @@ IFDEF EXPAND_TABLES
 	unusedSpace World3SpritePalettes + $30, $FF
 ENDIF
 
+;
+; #### World 4
+;
 World4BackgroundPalettes:
 	; Day
 	.db $23, $30, $12, $0F ; $00
@@ -262,6 +283,9 @@ IFDEF EXPAND_TABLES
 	unusedSpace World4SpritePalettes + $30, $FF
 ENDIF
 
+;
+; #### World 5
+;
 World5BackgroundPalettes:
 	; Night
 	.db $0F, $30, $12, $01 ; $00
@@ -316,6 +340,9 @@ IFDEF EXPAND_TABLES
 	unusedSpace World5SpritePalettes + $30, $FF
 ENDIF
 
+;
+; #### World 6
+;
 World6BackgroundPalettes:
 	; Day
 	.db $21, $30, $2A, $0F ; $00
@@ -370,6 +397,9 @@ IFDEF EXPAND_TABLES
 	unusedSpace World6SpritePalettes + $30, $FF
 ENDIF
 
+;
+; #### World 7
+;
 World7BackgroundPalettes:
 	; Day
 	.db $21, $30, $12, $0F ; $00
@@ -424,6 +454,20 @@ IFDEF EXPAND_TABLES
 	unusedSpace World7SpritePalettes + $30, $FF
 ENDIF
 
+;
+; ## Ground appearance tiles
+;
+; The ground setting defines a single column (or row, for vertical areas) where each row (or column)
+; is be one of four tiles. That set of four tiles is the ground appearance. Each world has its own
+; ground appearances defined, which are which are divided into horizontal and vertical sets.
+;
+; An area has its initial ground appearance set in the header, but it can be changed mid-area using
+; the `$F6` special object.
+;
+
+;
+; #### Ground appearance pointers
+;
 GroundTilesHorizontalLo:
 	.db <World1GroundTilesHorizontal
 	.db <World2GroundTilesHorizontal
@@ -461,8 +505,7 @@ GroundTilesVerticalHi:
 	.db >World7GroundTilesVertical
 
 ;
-; Ground appearance tiles
-; =======================
+; #### Ground appearance tile definitions
 ;
 ; These are the tiles used to render the ground setting of an area.
 ; Each row in a world's table corresponds to the ground type.
@@ -653,17 +696,23 @@ IFDEF EXPAND_TABLES
 	unusedSpace World7GroundTilesVertical + $40, $00
 ENDIF
 
-; These seem to be unused duplicates of the tile quads from bank F
+;
+; ## Tile quads (unused)
+;
+; These appear to be duplicates of the tile quads from bank F.
+;
 UnusedTileQuadPointersLo:
 	.db <UnusedTileQuads1
 	.db <UnusedTileQuads2
 	.db <UnusedTileQuads3
 	.db <UnusedTileQuads4
+
 UnusedTileQuadPointersHi:
 	.db >UnusedTileQuads1
 	.db >UnusedTileQuads2
 	.db >UnusedTileQuads3
 	.db >UnusedTileQuads4
+
 UnusedTileQuads1:
 	.db $FE,$FE,$FE,$FE ; $00
 	.db $B4,$B6,$B5,$B7 ; $04
@@ -700,6 +749,7 @@ UnusedTileQuads1:
 	.db $32,$34,$33,$35 ; $80
 	.db $33,$35,$33,$35 ; $84
 	.db $24,$26,$25,$27 ; $88
+
 UnusedTileQuads2:
 	.db $FA,$FA,$FA,$FA ; $00
 	.db $FA,$FA,$FA,$FA ; $04
@@ -760,6 +810,7 @@ UnusedTileQuads2:
 	.db $6C,$54,$6D,$55 ; $E0
 	.db $32,$34,$33,$35 ; $E4
 	.db $33,$35,$33,$35 ; $E8
+
 UnusedTileQuads3:
 	.db $94,$95,$94,$95 ; $00
 	.db $96,$97,$96,$97 ; $04
@@ -805,6 +856,7 @@ UnusedTileQuads3:
 	.db $72,$73,$4A,$4B ; $A4
 	.db $40,$42,$41,$43 ; $A8
 	.db $41,$43,$41,$43 ; $AC
+
 UnusedTileQuads4:
 	.db $40,$42,$41,$43 ; $00
 	.db $40,$42,$41,$43 ; $04
@@ -834,9 +886,17 @@ UnusedTileQuads4:
 
 
 ;
-; The $3X-$FX range is used for objects that specify a type in the upper nybble
-; and length in the lower nybble, including runs of horizontal or vertical
-; blocks, platforms, and waterfalls.
+; ## Object creation routine selection
+;
+; Object types are grouped into `$10` value ranges, where the upper nybble determines which routine
+; or jump table to use.
+;
+
+;
+; ### Length-based object table
+;
+; The `$3X-$FX` range is used for objects that specify a type in the upper nybble and length in the
+; lower nybble, including runs of horizontal or vertical blocks, platforms, and waterfalls.
 ;
 CreateObjects_30thruF0:
 	JSR JumpToTableAfterJump
@@ -861,9 +921,10 @@ ENDIF
 	.dw CreateObject_WaterfallOrFrozenRocks ; $FX
 
 ;
-; The $0X-$2X range is used for various single-block and one-off objects, such a
-; mushroom blocks, standable vines, doors, and vertical objects that extend all
-; the way to the ground.
+; ### Single object tables
+;
+; The `$0X-$2X` range is used for various single-block and one-off objects, such a mushroom blocks,
+; standable vines, doors, and vertical objects that extend all the way to the ground.
 ;
 CreateObjects_00:
 	JSR JumpToTableAfterJump
@@ -875,8 +936,7 @@ CreateObjects_00:
 	.dw CreateObject_SingleBlock ; $04
 IFNDEF LEVEL_ENGINE_UPGRADES
 	.dw CreateObject_SingleBlock ; $05
-ENDIF
-IFDEF LEVEL_ENGINE_UPGRADES
+ELSE
 	.dw CreateObject_StandableAutomatic ; $05
 ENDIF
 	.dw CreateObject_Vase ; $06
@@ -916,8 +976,7 @@ CreateObjects_20:
 
 
 ;
-; World Object Tiles
-; ==================
+; ## World object tiles
 ;
 ; The repeating blocks in the `$3X-$AX` range are specified per world in these
 ; lookup tables. Each world has 4 values for each object type, which are
@@ -1023,7 +1082,20 @@ World7ObjectTiles:
 	.db $81, $81, $81, $81 ; AX over background (ladder with shadow)
 
 
+;
+; ## Object creation routines
+;
+; These routines are responsible for turning an object in the level data into a set of tiles that
+; are applied to the raw tile buffer.
+;
+; Some are specific one-offs to draw a particular object, where as otherws are generic routines,
+; such as drawing an _n_-tile row or column of tile _x_. Many fall somewhere in-between.
+;
+
 IFDEF LEVEL_ENGINE_UPGRADES
+;
+; #### Automatic climbable tile generation
+;
 ClimbableTileSearch:
 	.db BackgroundTile_LadderShadow
 	.db BackgroundTile_Ladder
@@ -1040,12 +1112,12 @@ ClimbableTilePlatform:
 ;
 ; Find the corresponding climbable tile
 ;
-; Input
-;   A = search tile
+; ##### Input
+; - `A`: search tile
 ;
-; Output
-;   A = replace tile
-;   C = set if a match was found
+; ##### Output
+; - `A`: replace tile
+; - `C`: set if a match was found
 ;
 FindClimableTile:
 	STX byte_RAM_7
@@ -1068,10 +1140,10 @@ FindClimableTile_LoadReplacement:
 	RTS
 
 ;
-; Creates a climbable tile that you can stand on based on ObjectTypeAXthruFX
+; Creates a climbable tile that you can stand on based on `ObjectTypeAXthruFX`.
 ;
-; Output
-;   A = tile that was written
+; ##### Output
+; - `A`: tile that was written
 ;
 CreateObject_StandableObjectType:
 	LDA ObjectTypeAXthruFX
@@ -1105,10 +1177,10 @@ CreateObject_StandableObjectType_TableOffset:
 	RTS
 
 ;
-; Creates a climbable tile that you can stand on based on the based on the tile underneath
+; Creates a climbable tile that you can stand on based on the based on the tile underneath.
 ;
-; Output
-;   A = tile that was written
+; ##### Output
+; - `A`: tile that was written
 ;
 CreateObject_StandableAutomatic:
 	LDY byte_RAM_E7
@@ -1123,11 +1195,13 @@ ENDIF
 
 
 ;
-; Places a tile using the world-specific tile lookup table
+; Places a tile using the world-specific tile lookup table.
 ;
-; Input
-;   Y = destination tile
-;   byte_RAM_50E = type of object to create (upper nybble of level object minus 3)
+; ##### Input
+; - `Y`: destination tile
+; - `byte_RAM_50E`: type of object to create (upper nybble of level object minus 3)
+;
+;     ```
 ;     $00 = jumpthrough block
 ;     $01 = solid block
 ;     $02 = grass
@@ -1141,9 +1215,10 @@ ENDIF
 ;     $0A = log platform
 ;     $0B = cloud platform
 ;     $0C = waterfall
+;     ```
 ;
-; Output
-;   A = tile that was written
+; ##### Output
+; - `A`: tile that was written
 ;
 CreateWorldSpecificTile:
 	LDA byte_RAM_50E
@@ -1198,9 +1273,9 @@ CreateWorldSpecificTile_Exit:
 ;
 ; Creates a horizontal run of blocks
 ;
-; Input
-;   byte_RAM_50D = number of blocks to create
-;   byte_RAM_E7 = target tile placement offset
+; ##### Input
+; - `byte_RAM_50D`: number of blocks to create
+; - `byte_RAM_E7`: target tile placement offset
 ;
 CreateObject_HorizontalBlocks:
 	LDY byte_RAM_E7
@@ -1221,8 +1296,8 @@ CreateObject_HorizontalBlocks_Loop:
 ;
 ; World 6 has some extra logic to make the entrance extend down to the floor.
 ;
-; Input
-;   byte_RAM_E7 = target tile placement offset
+; ##### Input
+; - `byte_RAM_E7`: target tile placement offset
 ;
 CreateObject_LightEntranceRight:
 	LDA CurrentWorldTileset
@@ -1311,8 +1386,8 @@ CreateObject_LightEntranceRight_World6_Exit:
 ;
 ; Creates a light entrance with the trail facing left
 ;
-; Input
-;   byte_RAM_E7 = target tile placement offset
+; ##### Input
+; - `byte_RAM_E7`: target tile placement offset
 ;
 CreateObject_LightEntranceLeft:
 	LDY byte_RAM_E7
@@ -1352,11 +1427,13 @@ CreateObject_LightEntranceLeft_World6or7Exit:
 
 
 ;
-; Creates a vertical run of blocks
+; Creates a vertical run of blocks.
 ;
-; Input
-;   byte_RAM_50D = number of blocks to create
-;   byte_RAM_50E = type of object to create (upper nybble of level object minus 3)
+; ##### Input
+; - `byte_RAM_50D`: number of blocks to create
+; - `byte_RAM_50E`: type of object to create (upper nybble of level object minus 3)
+;
+;     ```
 ;     $00 = jumpthrough block
 ;     $01 = solid block
 ;     $02 = grass
@@ -1370,7 +1447,8 @@ CreateObject_LightEntranceLeft_World6or7Exit:
 ;     $0A = log platform
 ;     $0B = cloud platform
 ;     $0C = waterfall
-;   byte_RAM_E7 = target tile placement offset
+;     ```
+; - `byte_RAM_E7`: target tile placement offset
 ;
 CreateObject_VerticalBlocks:
 	LDY byte_RAM_E7
@@ -1473,8 +1551,8 @@ World7SingleBlocks:
 ;
 ; Creates a single block
 ;
-; Input
-;   byte_RAM_50E = object type to use as an offset in the lookup table
+; ##### Input
+; - `byte_RAM_50E`: object type to use as an offset in the lookup table
 ;
 CreateObject_SingleBlock:
 	LDA byte_RAM_50E
@@ -2317,10 +2395,10 @@ WhaleRightTiles:
 ;
 ; Draws a row of the whale
 ;
-; Input
-;   byte_RAM_E7 = target tile placement offset
-;   byte_RAM_50D = width of house
-;   byte_RAM_50E = offset in the tile lookup table plus $0A, for some reason
+; ##### Input
+; - `byte_RAM_E7`: target tile placement offset
+; - `byte_RAM_50D`: width of house
+; - `byte_RAM_50E`: offset in the tile lookup table plus `$0A`, for some reason
 ;
 CreateObject_WhaleRow:
 	LDY byte_RAM_E7
@@ -2370,8 +2448,8 @@ ENDIF
 ;
 ; Draws a whale.
 ;
-; Input
-;   byte_RAM_50D = width of whale
+; ##### Input
+; - `byte_RAM_50D`: width of whale
 ;
 CreateObject_Whale:
 	LDA byte_RAM_50D
@@ -2539,8 +2617,8 @@ CreateObject_HorizontalPlatform_World5_Exit:
 ;
 ; Check if the next platform tile overlaps the background
 ;
-; Output
-;   X = table offset for (2 if there is an overlap)
+; ##### Output
+; - `X`: table offset for (2 if there is an overlap)
 ;
 CreateObject_HorizontalPlatform_World5CheckOverlap:
 	STX byte_RAM_7
@@ -2567,9 +2645,9 @@ TreeBackgroundTiles:
 ;
 ; Creates a tree background
 ;
-; Input
-;   byte_RAM_E7 = target tile placement offset
-;   byte_RAM_E8 = area page
+; ##### Input
+; - `byte_RAM_E7`: target tile placement offset
+; - `byte_RAM_E8`: area page
 ;
 CreateObject_TreeBackground:
 	; width of the middle of the tree (0 = two tiles, 4 = ten tiles)
@@ -2739,9 +2817,9 @@ DoorBottomTiles:
 ;
 ; Creates a door object.
 ;
-; Input
-;   byte_RAM_E7 = target tile placement offset
-;   byte_RAM_50E = type of object to create
+; ##### Input
+; - `byte_RAM_E7`: target tile placement offset
+; - `byte_RAM_50E`: type of object to create
 ;
 CreateObject_Door:
 	LDY byte_RAM_E7
@@ -2833,10 +2911,10 @@ MushroomHouseRightTiles:
 ;
 ; Draws a row of the mushroom house
 ;
-; Input
-;   byte_RAM_E7 = target tile placement offset
-;   byte_RAM_50D = width of house
-;   byte_RAM_50E = offset in the tile lookup table plus $0A, for some reason
+; ##### Input
+; - `byte_RAM_E7`: target tile placement offset
+; - `byte_RAM_50D`: width of house
+; - `byte_RAM_50E`: offset in the tile lookup table plus $0A, for some reason
 ;
 CreateObject_MushroomHouseRow:
 	LDY byte_RAM_E7
@@ -2930,8 +3008,8 @@ PillarBottomTiles:
 ;
 ; Draws a pillar that extends to the ground
 ;
-; Input
-;   byte_RAM_E7 = target tile placement offset
+; ##### Input
+; - `byte_RAM_E7`: target tile placement offset
 ;
 CreateObject_Pillar:
 	LDX CurrentWorldTileset
@@ -2972,8 +3050,8 @@ CreateObject_Pillar_Exit:
 ;
 ; Draws one horn of Wart's vegetable thrower
 ;
-; Input
-;   byte_RAM_E7 = target tile placement offset
+; ##### Input
+; - `byte_RAM_E7`: target tile placement offset
 ;
 CreateObject_Horn:
 	LDY byte_RAM_E7
@@ -2997,8 +3075,8 @@ CreateObject_Horn:
 ;
 ; Draws the drawbridge chain
 ;
-; Input
-;   byte_RAM_E7 = target tile placement offset
+; ##### Input
+; - `byte_RAM_E7`: target tile placement offset
 ;
 CreateObject_DrawBridgeChain:
 	LDY byte_RAM_E7
@@ -3021,22 +3099,30 @@ IFNDEF EXPAND_TABLES
 unusedSpace $9200, $FF
 ENDIF
 
+;
+; ## Ground setting data
+;
+; The ground setting defines a single column (or row, for vertical areas) where each row (or column)
+; can be one of four tiles. These tiles are repeated until an object changes  the ground setting or
+; the renderer reaches the the end of the area.
+;
+; An area has its initial ground setting set in the header, but it can be changed mid-area using the
+; `$F0` and `$F1` special objects.
+;
 
 ;
-; Horizontal ground set data
-; ==========================
+; #### Horizontal ground set data
 ;
-; Two bits per tile
+; Two bits per tile are used to select from one of the four ground appearance tiles. The tiles are
+; defined from top-to-bottom, except for the last tile, which is actually the top row!
 ;
-; It seems to go top-to-bottom except for the last tile, which is actually the top?
+; Ground appearance tiles are defined xpecifically in the `WorldXGroundTilesHorizontal` lookup
+; tables, but here's an example of how they apply:
 ;
-; The tiles are defined in the WorldXGroundTilesHorizontal lookup tables, but
-; here's an example of how they apply:
-;
-;   00 - default background (ie. sky)
-;   01 - secondary platform (eg. sand)
-;   10 - primary platform (eg. grass)
-;   11 - secondary background (eg. black background in 3-2)
+; - `%00`: default background (ie. sky)
+; - `%01`: secondary platform (eg. sand)
+; - `%10`: primary platform (eg. grass)
+; - `%11`: secondary background (eg. black background in 3-2)
 ;
 HorizontalGroundSetData:
 	.db $00,$00,$00,$24 ; $00
@@ -3077,18 +3163,18 @@ IFDEF EXPAND_TABLES
 ENDIF
 
 ;
-; Vertical ground set data
-; ========================
+; #### Vertical ground set data
 ;
-; Two bits per tile, left-to-right
+; Two bits per tile are used to select from one of the four ground appearance tiles. The tiles are
+; defined from left-to-right.
 ;
-; The tiles are defined in the WorldXGroundTilesVertical lookup tables, but
-; here's an example of how they apply:
+; Ground appearance tiles are defined xpecifically in the `WorldXGroundTilesVertical` lookup
+; tables, but here's an example of how they apply:
 ;
-;   00 - default background (ie. sky)
-;   01 - secondary platform (eg. bombable wall, sand)
-;   10 - primary platform
-;   11 - secondary background
+; - `%00`: default background (ie. sky)
+; - `%01`: secondary platform (eg. bombable wall, sand)
+; - `%10`: primary platform
+; - `%11`: secondary background
 ;
 VerticalGroundSetData:
 	.db $AA,$AA,$AA,$AA ; $00
@@ -3231,7 +3317,10 @@ ENDIF
 
 
 ;
-; Resets level data and PPU scrolling
+; Resets level data and PPU scrolling.
+;
+; This starts at the end of the last page and works backwards to create a blank slate upon which to
+; render the current area's level data.
 ;
 ResetLevelData:
 	LDA #<DecodedLevelData
@@ -3239,6 +3328,8 @@ ResetLevelData:
 	LDY #>(DecodedLevelData+$0900)
 	STY byte_RAM_B
 	LDY #>(DecodedLevelData-$0100)
+
+	; Set all tiles to sky
 	LDA #BackgroundTile_Sky
 
 ResetLevelData_Loop:
@@ -3269,10 +3360,11 @@ ResetLevelData_Loop:
 ;
 ; Reads a color from the world's background palette
 ;
-; Input
-;   X = color index
-; Output
-;   A = background palette color
+; ##### Input
+; - `X`: color index
+;
+; ##### Output
+; - `A`: background palette color
 ;
 ReadWorldBackgroundColor:
 	; stash X and Y registers
@@ -3295,10 +3387,11 @@ ReadWorldBackgroundColor:
 ;
 ; Reads a color from the world's sprite palette
 ;
-; Input
-;   X = color index
-; Output
-;   A = background palette color
+; ##### Input
+; - `X`: color index
+;
+; ##### Output
+; - `A`: background palette color
 ;
 ReadWorldSpriteColor:
 	; stash X and Y registers
@@ -3347,8 +3440,8 @@ LoadCurrentPalette_AreaOffset:
 ;
 ; Loads a world palette to RAM
 ;
-; Input
-;   A = background palette header byte
+; ##### Input
+; - `A`: background palette header byte
 ;
 ApplyPalette:
 	; Read background palette index from area header byte
@@ -3487,14 +3580,15 @@ GenerateSubspaceArea_TileRemapLoop:
 
 
 ;
-; Remaps a single subspace tile
+; Remaps a single subspace tile.
 ;
-; This also handles creating the mushroom sprites
+; This also handles creating the mushroom sprites.
 ;
-; Input
-;   A = input tile
-; Output
-;   A = output tile
+; ##### Input
+; - `A`: input tile
+;
+; ##### Output
+; - `A`: output tile
 ;
 DoSubspaceTileRemap:
 	STY byte_RAM_8
@@ -3524,7 +3618,7 @@ DoSubspaceTileRemap_CheckCreateMushroom:
 	BNE DoSubspaceTileRemap_AfterCreateMushroom
 
 	LDX byte_RAM_7
-	JSR CreateMushroomObject
+	JSR CreateSubspaceMushroomObject
 
 DoSubspaceTileRemap_AfterCreateMushroom:
 	LDA #BackgroundTile_SubspaceMushroom1
@@ -3569,7 +3663,7 @@ ClearSubAreaTileLayout_Loop:
 	LDY #$03
 	STY GroundSetting
 	LDY #$04
-	JSR loc_BANK6_972D
+	JSR ReadLevelBackgroundData_Page
 
 	; object type
 	LDY #$02
@@ -3583,23 +3677,23 @@ ClearSubAreaTileLayout_Loop:
 	STA ObjectTypeAXthruFX
 	JSR HijackLevelDataCopyAddressWithJar
 
-	LDA #$A
+	LDA #$0A
 	STA byte_RAM_E8
 	LDA #$00
 	STA byte_RAM_E6
 	STA byte_RAM_E5
 	LDA #$03
 	STA byte_RAM_4
-	JSR ReadLevelData_NextByteObject
+	JSR ReadLevelForegroundData_NextByteObject
 
 	LDA #$01
 	STA IsHorizontalLevel
 	RTS
 
 ;
-; Set the current background music to the current area's music as defined in the header
+; Set the current background music to the current area's music as defined in the header.
 ;
-; This stops the current music unless the player is currently invincible
+; This stops the current music unless the player is currently invincible.
 ;
 LoadAreaMusic:
 	LDY #$03
@@ -3668,20 +3762,31 @@ Unused_ChangeAreaMusic_Exit:
 
 
 ;
-; Resets the level data, loads the current area's level data, and queues any music changes
+; ## Area loading and rendering
+;
+; This is the main subroutine for parsing and rendering an entire area of a level.
 ;
 LoadCurrentArea:
+	; First, reset the level data and PPU scrolling.
 	JSR ResetLevelData
 
-	JSR sub_BANK6_98DC
+	JSR ResetPPUScrollHi_Bank6
 
+	; Determine the address of the raw level data.
 	JSR RestoreLevelDataCopyAddress
 
+	;
+	; ### Read area header
+	;
+	; The level header is read backwards starting at the last byte.
+	;
+
+	; Queue any changes to the background music.
 	JSR LoadAreaMusic
 
-	; read the level header
-
-	; ground type
+	;
+	; Load initial ground appearance, which determines the tiles used for the background.
+	;
 	LDY #$03
 	LDA (byte_RAM_5), Y
 IFNDEF LEVEL_ENGINE_UPGRADES
@@ -3694,12 +3799,13 @@ ELSE
 	LSR A
 ENDIF
 
-	; store ground type
 	STA GroundType
+
+	; This doesn't hurt, but shouldn't be necessary.
 	JSR RestoreLevelDataCopyAddress
 
 IFDEF ENABLE_LEVEL_OBJECT_MODE
-	; level object mode
+	; Read level object mode.
 	LDA (byte_RAM_5), Y
 	LSR A
 	LSR A
@@ -3707,7 +3813,7 @@ IFDEF ENABLE_LEVEL_OBJECT_MODE
 	STA LevelObjectMode
 ENDIF
 
-	; horizontal or vertical level
+	; Determine whether this area is Horizontal or vertical.
 	LDY #$00
 	LDA (byte_RAM_5), Y
 	ASL A
@@ -3715,11 +3821,11 @@ ENDIF
 	ROL A
 	STA IsHorizontalLevel
 
-	; reset the screen position?
+	; Reset the area page so that we can start drawing from the beginning.
 	LDA #$00
 	STA byte_RAM_E8
 
-	; level length (pages)
+	; Determine the level length (in pages).
 	LDY #$02
 	LDA (byte_RAM_5), Y
 	LSR A
@@ -3728,7 +3834,8 @@ ENDIF
 	LSR A
 	STA CurrentLevelPages
 
-	; object type
+	; Determine the object types, which are used to determine which horizontal and vertical blocks are
+	; used, as well as how some climbable objects appear.
 	LDA (byte_RAM_5), Y
 	AND #%00000011
 	STA ObjectType3Xthru9X
@@ -3740,7 +3847,7 @@ ENDIF
 	DEY
 
 IFDEF AREA_HEADER_TILESET
-	; tileset
+	; World tileset to use for the area.
 	LDA (byte_RAM_5), Y
 	ROL A
 	ROL A
@@ -3754,33 +3861,61 @@ LoadCurrentArea_IsValid:
 	STA CurrentWorldTileset
 ENDIF
 
-	; ground setting
+	; Load initial ground setting, which determines the shape of the ground layout.
+	;
+	; Using `$1F` skips rendering ground settings entirely, but no areas seem to use it.
 	LDA (byte_RAM_5), Y
 	AND #%00011111
-	; ground setting of $1F would skip the next part, but no areas do this...?
 	CMP #%00011111
-	BEQ LoadCurrentArea_StartLevelData
+	BEQ LoadCurrentArea_ForegroundData
 
-	; store ground setting
 	STA GroundSetting
 
-	; read first object
+	;
+	; ### Process level data
+	;
+	; The area is rendered in two passes (with the exception described above).
+	;
+
+	;
+	; #### First pass: background terrain
+	;
+	; The first pass applies the ground settings and appearance to the entire area. This makes sure
+	; that the ground is already in place when rendering objects that extend to the ground, such as
+	; trees, vines, and platforms.
+	;
+
+	; Advance to the first object in the level data.
 	INY
 	INY
 	INY
+
+	; Reset the tile placement offset for the first pass.
 	LDA #$00
 	STA byte_RAM_E5
 	STA byte_RAM_E6
-	JSR sub_BANK6_9728
 
-LoadCurrentArea_StartLevelData:
+	; Run the first pass of level rendering to apply ground settings and appearance.
+	JSR ReadLevelBackgroundData
+
+	;
+	; #### Second pass: foreground objects
+	;
+	; The second pass renders normal level objects and sets up area pointers.
+	;
+LoadCurrentArea_ForegroundData:
+	; Reset the tile placement offset for the second pass.
 	LDA #$00
 	STA byte_RAM_E6
-	; byte_RAM_4 is the offset of the byte before the next level data byte
+
+	; Advance to the first object in the level data.
 	LDA #$03
 	STA byte_RAM_4
-	JSR ReadLevelData
 
+	; Run the second pass of level rendering to place regular objects in the level.
+	JSR ReadLevelForegroundData
+
+	; Bootstrap the pseudo-random number generator.
 	LDA #$22
 	ORA byte_RAM_10
 	STA PseudoRNGValues
@@ -3788,7 +3923,7 @@ LoadCurrentArea_StartLevelData:
 
 
 ;
-; Use level data
+; Sets the raw level data pointer to the level data.
 ;
 RestoreLevelDataCopyAddress:
 	LDA #>RawLevelData
@@ -3799,7 +3934,9 @@ RestoreLevelDataCopyAddress:
 
 
 ;
-; Use jar data
+; Sets the raw level data pointer to the jar data.
+;
+; This is what allows jars to load so quickly.
 ;
 HijackLevelDataCopyAddressWithJar:
 	LDA #>RawJarData
@@ -3810,29 +3947,34 @@ HijackLevelDataCopyAddressWithJar:
 
 
 ;
-; Reads level data from the beginning
+; ### Render foreground level data
 ;
-ReadLevelData:
+; Reads level data from the beginning and processes individual objects.
+;
+; ##### Input
+; - `byte_RAM_4`: raw data offset
+;
+ReadLevelForegroundData:
 	; start at area page 0
 	LDA #$00
 	STA byte_RAM_E8
 
 	; weird? the next lines do nothing
 	LDY #$00
-	JMP ReadLevelData_NextByteObject
+	JMP ReadLevelForegroundData_NextByteObject
 
-ReadLevelData_NextByteObject:
+ReadLevelForegroundData_NextByteObject:
 	LDY byte_RAM_4
 
-ReadLevelData_NextByte:
+ReadLevelForegroundData_NextByte:
 	INY
 	LDA (byte_RAM_5), Y
 	CMP #$FF
-	BNE ReadLevelData_ProcessObject
-	; encountering $FF indicates the end of the level data
+	BNE ReadLevelForegroundData_ProcessObject
+	; Encountering `$FF` indicates the end of the level data.
 	RTS
 
-ReadLevelData_ProcessObject:
+ReadLevelForegroundData_ProcessObject:
 	; Stash the lower nybble of the first byte.
 	; For a special object, this will be the special object type.
 	; For a regular object, this will be the X position.
@@ -3843,17 +3985,17 @@ ReadLevelData_ProcessObject:
 	LDA (byte_RAM_5), Y
 	AND #$F0
 	CMP #$F0
-	BNE ReadLevelData_RegularObject
+	BNE ReadLevelForegroundData_RegularObject
 
-ReadLevelData_SpecialObject:
+ReadLevelForegroundData_SpecialObject:
 	LDA byte_RAM_E5
 	STY byte_RAM_F
-	JSR ProcessSpecialObjectA
+	JSR ProcessSpecialObjectForeground
 
 	LDY byte_RAM_F
-	JMP ReadLevelData_NextByte
+	JMP ReadLevelForegroundData_NextByte
 
-ReadLevelData_RegularObject:
+ReadLevelForegroundData_RegularObject:
 	JSR UpdateAreaYOffset
 
 	; check object type
@@ -3866,15 +4008,15 @@ ReadLevelData_RegularObject:
 	LSR A
 	STA byte_RAM_50E
 	CMP #$03
-	BCS ReadLevelData_RegularObjectWithSize
+	BCS ReadLevelForegroundData_RegularObjectWithSize
 
-ReadLevelData_RegularObjectNoSize:
+ReadLevelForegroundData_RegularObjectNoSize:
 	PHA
 	LDA (byte_RAM_5), Y
 	AND #$0F
 	STA byte_RAM_50E
 	PLA
-	BEQ ReadLevelData_RegularObjectNoSize_00
+	BEQ ReadLevelForegroundData_RegularObjectNoSize_00
 
 	PHA
 	JSR SetTileOffsetAndAreaPageAddr_Bank6
@@ -3884,24 +4026,24 @@ ReadLevelData_RegularObjectNoSize:
 	STY byte_RAM_4
 	PLA
 	CMP #$01
-	BNE ReadLevelData_RegularObjectNoSize_Not10
+	BNE ReadLevelForegroundData_RegularObjectNoSize_Not10
 
-ReadLevelData_RegularObjectNoSize_10:
+ReadLevelForegroundData_RegularObjectNoSize_10:
 	JSR CreateObjects_10
-	JMP ReadLevelData_RegularObject_Exit
+	JMP ReadLevelForegroundData_RegularObject_Exit
 
-ReadLevelData_RegularObjectNoSize_Not10:
+ReadLevelForegroundData_RegularObjectNoSize_Not10:
 	CMP #$02
-	BNE ReadLevelData_RegularObjectNoSize_Not20
+	BNE ReadLevelForegroundData_RegularObjectNoSize_Not20
 
-ReadLevelData_RegularObjectNoSize_20:
+ReadLevelForegroundData_RegularObjectNoSize_20:
 	JSR CreateObjects_20
-	JMP ReadLevelData_RegularObject_Exit
+	JMP ReadLevelForegroundData_RegularObject_Exit
 
-ReadLevelData_RegularObjectNoSize_Not20:
-	JMP ReadLevelData_RegularObject_Exit
+ReadLevelForegroundData_RegularObjectNoSize_Not20:
+	JMP ReadLevelForegroundData_RegularObject_Exit
 
-ReadLevelData_RegularObjectWithSize:
+ReadLevelForegroundData_RegularObjectWithSize:
 	LDA (byte_RAM_5), Y
 	AND #$0F
 	STA byte_RAM_50D
@@ -3914,10 +4056,10 @@ ReadLevelData_RegularObjectWithSize:
 	STA byte_RAM_50E
 	JSR CreateObjects_30thruF0
 
-ReadLevelData_RegularObject_Exit:
-	JMP ReadLevelData_NextByteObject
+ReadLevelForegroundData_RegularObject_Exit:
+	JMP ReadLevelForegroundData_NextByteObject
 
-ReadLevelData_RegularObjectNoSize_00:
+ReadLevelForegroundData_RegularObjectNoSize_00:
 	JSR SetTileOffsetAndAreaPageAddr_Bank6
 
 	LDA (byte_RAM_5), Y
@@ -3925,14 +4067,14 @@ ReadLevelData_RegularObjectNoSize_00:
 	STY byte_RAM_4
 	JSR CreateObjects_00
 
-	JMP ReadLevelData_RegularObject_Exit
+	JMP ReadLevelForegroundData_RegularObject_Exit
 
 
 ;
 ; Updates the area Y offset for object placement
 ;
-; Input
-;   A = vertical offset
+; ##### Input
+; - `A`: vertical offset
 ;
 UpdateAreaYOffset:
 	CLC
@@ -3957,16 +4099,22 @@ UpdateAreaYOffset_Exit:
 
 
 ;
-; First pass of processing consumes bytes
+; Processes special objects for the second pass, which draws object tiles.
 ;
-ProcessSpecialObjectA:
+; On this pass, ground setting tiles are ignored, and we're just eating the bytes, but page skip
+; objects still require updating the tile placement cursor.
+;
+; Area pointers are also processed in this pass. Although they _could_ be processed earlier, this
+; reduces the likelihood of being overridden by a door pointer.
+;
+ProcessSpecialObjectForeground:
 	JSR JumpToTableAfterJump
 
 	.dw EatLevelObject1Byte ; Ground setting 0-8
 	.dw EatLevelObject1Byte ; Ground setting 9-15
-	.dw SkipForwardPage1 ; Skip forward 1 page
-	.dw SkipForwardPage2 ; Skip forward 2 pages
-	.dw ResetPageAndOffset ; New object layer
+	.dw SkipForwardPage1Foreground ; Skip forward 1 page
+	.dw SkipForwardPage2Foreground ; Skip forward 2 pages
+	.dw ResetPageAndOffsetForeground ; New object layer
 	.dw SetAreaPointer ; Area pointer
 	.dw EatLevelObject1Byte ; Ground appearance
 IFDEF LEVEL_ENGINE_UPGRADES
@@ -3974,14 +4122,17 @@ IFDEF LEVEL_ENGINE_UPGRADES
 ENDIF
 
 
-ProcessSpecialObjectB:
+;
+; Processes special objects for the first pass, which draws ground layout tiles.
+;
+ProcessSpecialObjectBackground:
 	JSR JumpToTableAfterJump
 
 	.dw SetGroundSettingA ; Ground setting 0-7
 	.dw SetGroundSettingB ; Ground setting 8-15
-	.dw SkipForwardPage1B ; Skip forward 1 page
-	.dw SkipForwardPage2B ; Skip forward 2 pages
-	.dw loc_BANK6_9712 ; New object layer
+	.dw SkipForwardPage1Background ; Skip forward 1 page
+	.dw SkipForwardPage2Background ; Skip forward 2 pages
+	.dw ResetPageAndOffsetBackground ; New object layer
 	.dw SetAreaPointerNoOp ; Area pointer
 	.dw SetGroundType ; Ground appearance
 IFDEF LEVEL_ENGINE_UPGRADES
@@ -3990,17 +4141,21 @@ ENDIF
 
 
 ;
-; Moves the tile placement cursor forward to the beginning of the page after next.
+; #### Special Object `$F2` / `$F3`: Skip Page (Foreground)
 ;
-; Output
-;   byte_RAM_E8 = area page
-;   byte_RAM_E6 = tile placement offset
+; Moves the tile placement cursor forward one or two pages in the foregorund pass.
 ;
-SkipForwardPage2:
+; ##### Output
+;
+; - `byte_RAM_E8`: area page
+; - `byte_RAM_E6`: tile placement offset
+;
+;
+
+SkipForwardPage2Foreground:
 	INC byte_RAM_E8
 
-; Moves the tile placement cursor forward to the beginning of the next page.
-SkipForwardPage1:
+SkipForwardPage1Foreground:
 	INC byte_RAM_E8
 	LDA #$00
 	STA byte_RAM_E6
@@ -4008,18 +4163,21 @@ SkipForwardPage1:
 
 
 ;
-; Advances the last page pointer by two pages.
+; #### Special Object `$F2` / `$F3`: Skip Page (Background)
 ;
-; Output
-;   byte_RAM_540 = last page?
-;   byte_RAM_E = ???
-;   byte_RAM_9 = ???
+; Moves the tile placement cursor forward one or two pages in the background pass.
 ;
-SkipForwardPage2B:
+; ##### Output
+;
+; - `byte_RAM_540`: area page
+; - `byte_RAM_E`: tile placement offset
+; - `byte_RAM_9`: tile placement offset (overflow counter)
+;
+
+SkipForwardPage2Background:
 	INC byte_RAM_540
 
-; Advances the last page pointer by one pages.
-SkipForwardPage1B:
+SkipForwardPage1Background:
 	INC byte_RAM_540
 	LDA #$00
 	STA byte_RAM_E
@@ -4043,14 +4201,16 @@ EatLevelObject1Byte:
 
 
 ;
+; #### Area Pointer Object `$F5`
+;
 ; Sets the area pointer for this page.
 ;
-; Input
-;   byte_RAM_F = level data byte offset
-;   byte_RAM_E8 = area page
+; ##### Input
+; - `byte_RAM_F`: level data byte offset
+; - `byte_RAM_E8`: area page
 ;
-; Output
-;   byte_RAM_F = level data byte offset
+; ##### Output
+; - `byte_RAM_F`: level data byte offset
 ;
 SetAreaPointer:
 	LDY byte_RAM_F
@@ -4070,16 +4230,15 @@ SetAreaPointer:
 
 IFDEF LEVEL_ENGINE_UPGRADES
 ;
-; Special Object $F7
-; ==================
+; #### Special Object `$F7`
 ;
-; Creates a run of 1-16 arbitrary tiles
+; Creates a run of 1-16 arbitrary tiles.
 ;
-; Usage: $F7 $YX $WL ...
-;    Y - relative Y offset on page
-;    X - X position on page
-;    W - wrap width (eg. 0 for no wrap, 2 for 2-tiles wide, etc.)
-;    L - run length, L+1 subsequent bytes are the raw tiles
+; #### Usage: `$F7 $YX $WL ...`
+; - `Y`: relative Y offset on page
+; - `X`: X position on page
+; - `W`: wrap width (eg. 0 for no wrap, 2 for 2-tiles wide, etc.)
+; - `L`: run length, L+1 subsequent bytes are the raw tiles
 ;
 CreateRawTiles:
 	LDY byte_RAM_F
@@ -4178,8 +4337,8 @@ ENDIF
 ;
 ; Use top 3 bits for the X offset of a ground setting object
 ;
-; Output
-;   A = 0-7
+; ##### Output
+; - `A`: 0-7
 ;
 ReadGroundSettingOffset:
 	LDY byte_RAM_F
@@ -4193,12 +4352,25 @@ ReadGroundSettingOffset:
 	LSR A
 	RTS
 
-; Ground setting for X=0 through X=7
+;
+; #### Special Object `$F0` / `$F1`: Ground Setting
+;
+; Sets ground setting at some relative offset on the current page.
+;
+; Object `$F0` can change the ground setting for offsets 0 through 7.
+; Object `$F1` can change the ground setting for offsets 8 through 15.
+;
+; #### Input
+; - `A`: Relative offset (0-7)
+; - `byte_RAM_F`: level data byte offset
+;
+; #### Output
+; - `byte_RAM_E`: tile placement offset
+;
 SetGroundSettingA:
 	JSR ReadGroundSettingOffset
 	JMP SetGroundSetting
 
-; Ground setting for X=8 through X=15
 SetGroundSettingB:
 	JSR ReadGroundSettingOffset
 	CLC
@@ -4221,26 +4393,55 @@ SetGroundSetting_Exit:
 
 
 ;
-; Moves the tile placement cursor to the beginning of the first page.
+; #### Special Object `$F4`: New Layer (Foreground)
 ;
-ResetPageAndOffset:
+; Moves the tile placement cursor to the beginning of the first page in the foreground pass.
+;
+; ##### Output
+;
+; - `byte_RAM_E8`: area page
+; - `byte_RAM_E6`: tile placement offset
+;
+ResetPageAndOffsetForeground:
 	LDA #$00
 	STA byte_RAM_E8 ; area page
 	STA byte_RAM_E6 ; tile placement offset
 	RTS
 
 
-loc_BANK6_9712:
+;
+; #### Special Object `$F4`: New Layer (Background)
+;
+; Moves the tile placement cursor to the beginning of the first page in the background pass.
+;
+; ##### Output
+;
+; - `byte_RAM_540`: area page
+; - `byte_RAM_E`: tile placement offset
+;
+ResetPageAndOffsetBackground:
 	LDA #$00
 	STA byte_RAM_540
 	STA byte_RAM_E
 	RTS
 
 
+;
+; Area pointers are not processed on the background pass.
+;
 SetAreaPointerNoOp:
 	RTS
 
 
+;
+; #### Ground Appearance Object `$F6`
+;
+; Sets the ground appearance, which determines the tiles used when drawing the ground setting.
+;
+; ##### Output
+;
+; `GroundType`: the ground type used for drawing the background
+;
 SetGroundType:
 	LDY byte_RAM_F
 	INY
@@ -4251,159 +4452,223 @@ SetGroundType:
 	STA GroundType
 	RTS
 
-; =============== S U B R O U T I N E =======================================
 
-; used for the first object of a level?
-sub_BANK6_9728:
+;
+; ### Render background level data
+;
+; Reads level data from the beginning and processes the ground layout.
+;
+; This first pass is used for setting up the ground types and settings before normal objects are
+; rendered in the level.
+;
+; ##### Input
+; - `Y`: raw data offset
+;
+ReadLevelBackgroundData:
 	LDA #$00
 	STA byte_RAM_540
 
-loc_BANK6_972D:
+ReadLevelBackgroundData_Page:
 	LDA #$00
 	STA byte_RAM_9
 
-loc_BANK6_9731:
+ReadLevelBackgroundData_Object:
 	LDA (byte_RAM_5), Y
 	CMP #$FF
-	BNE loc_BANK6_9746
+	BNE ReadLevelBackgroundData_ProcessObject
 
-	; end of level data
+	; Encountering `$FF` indicates the end of the level data.
+
+	; Render the remaining ground setting through the end of the last page in the area.
 	LDA #$0A
 	STA byte_RAM_540
 	INC byte_RAM_540
 	LDA #$00
 	STA byte_RAM_E
-	JMP loc_BANK6_978C
+	JMP ReadLevelBackgroundData_RenderGround
 
-; ---------------------------------------------------------------------------
-
-loc_BANK6_9746:
+ReadLevelBackgroundData_ProcessObject:
 	LDA (byte_RAM_5), Y
 	AND #$F0
-	BEQ loc_BANK6_976F
+	BEQ ReadLevelBackgroundData_ProcessObject_Advance2Bytes
 
 	CMP #$F0
-	BNE loc_BANK6_9774
+	BNE ReadLevelBackgroundData_ProcessRegularObject
 
-	; a special object
+;
+; First byte of `$FX` indicates a special object.
+;
+ReadLevelBackgroundData_ProcessSpecialObject:
 	LDA (byte_RAM_5), Y
 	AND #$0F
 	STY byte_RAM_F
-	JSR ProcessSpecialObjectB
+	JSR ProcessSpecialObjectBackground
 
+	; Determine how many more bytes to advance after processing the special object.
 	LDY byte_RAM_F
 	LDA (byte_RAM_5), Y
 	AND #$0F
+
+	; Ground setting `$F0` / `$F1` should render the previous ground setting
 	CMP #$02
-	BCC loc_BANK6_978C
+	BCC ReadLevelBackgroundData_RenderGround
 
+	; Special objects except `$F0` / `$F1`
 	CMP #$05
-	BNE loc_BANK6_976B
+	BNE ReadLevelBackgroundData_ProcessObject_NotF5
 
+ReadLevelBackgroundData_ProcessObject_Advance3Bytes:
 	INY
-	JMP loc_BANK6_976F
+	JMP ReadLevelBackgroundData_ProcessObject_Advance2Bytes
 
-; ---------------------------------------------------------------------------
-
-loc_BANK6_976B:
+ReadLevelBackgroundData_ProcessObject_NotF5:
+	; Special objects except `$F0` / `$F1` / `$F5`
 	CMP #$06
-	BNE loc_BANK6_9770
+	BNE ReadLevelBackgroundData_ProcessObject_AdvanceByte
 
-loc_BANK6_976F:
+; Ground appearance `$F6` is two bytes.
+ReadLevelBackgroundData_ProcessObject_Advance2Bytes:
 	INY
 
-loc_BANK6_9770:
+ReadLevelBackgroundData_ProcessObject_AdvanceByte:
 	INY
-	JMP loc_BANK6_9731
+	JMP ReadLevelBackgroundData_Object
 
-; ---------------------------------------------------------------------------
-
-; not a special object
-loc_BANK6_9774:
+;
+; Processes a regular object, as indicated by a value of `$0X-$EX` in the first byte.
+;
+; ##### Input
+; - `byte_RAM_9`: tile placement offset (overflow counter)
+;
+; ##### Output
+; - `byte_RAM_540`: area page
+; - `byte_RAM_9`: tile placement offset (overflow counter)
+;
+; Since we're only processing background objects, all this needs to do is look at the object offset
+; and advance the tile placement cursor and current page as needed.
+;
+; #### The Door Pointer Y Offset "Bug"
+;
+; An interesting quirk about the level engine is that door pointers are used in worlds 1-5, but not
+; worlds 6 and 7, due to the fact that the pointers have an effective Y offset of 1.
+;
+; The developers chose to disable door pointers to deal with this problem, but another solution
+; would have been to modify the code here to determine whether an object was being used as a door
+; pointer and avoid processing its position offset.
+;
+ReadLevelBackgroundData_ProcessRegularObject:
 	CLC
 	ADC byte_RAM_9
-	BCC loc_BANK6_977E
+	BCC ReadLevelBackgroundData_ProcessRegularObject_SamePage
 
+	; The object position overflowed to the next page.
 	ADC #$0F
-	JMP loc_BANK6_9784
+	JMP ReadLevelBackgroundData_ProcessRegularObject_NextPage
 
-; ---------------------------------------------------------------------------
-
-loc_BANK6_977E:
+ReadLevelBackgroundData_ProcessRegularObject_SamePage:
 	CMP #$F0
-	BNE loc_BANK6_9787
+	BNE ReadLevelBackgroundData_ProcessRegularObject_Exit
 
 	LDA #$00
 
-loc_BANK6_9784:
+ReadLevelBackgroundData_ProcessRegularObject_NextPage:
 	INC byte_RAM_540
 
-loc_BANK6_9787:
+ReadLevelBackgroundData_ProcessRegularObject_Exit:
 	STA byte_RAM_9
-	JMP loc_BANK6_976F
+	JMP ReadLevelBackgroundData_ProcessObject_Advance2Bytes
 
-; ---------------------------------------------------------------------------
 
-loc_BANK6_978C:
+;
+; Renders the ground setting up to this point.
+;
+; This code is invoked when we encounter a ground setting object and need to render the previous
+; ground setting up tothis point or when we have reached the end of the level data and need to
+; render the current ground setting through the end of the area.
+;
+; #### Input
+; - `byte_RAM_E8`: area page
+; - `byte_RAM_E5`: tile placement offset shift
+; - `byte_RAM_E6`: previous tile placement offset
+; - `byte_RAM_540`: area page (end)
+; - `byte_RAM_E`: tile placement offset (end)
+;
+; #### Output
+;
+ReadLevelBackgroundData_RenderGround:
 	JSR SetTileOffsetAndAreaPageAddr_Bank6
 
 	JSR LoadGroundSetData
 
 	LDA IsHorizontalLevel
-	BEQ loc_BANK6_97A7
+	BEQ ReadLevelBackgroundData_RenderGround_Vertical
 
+ReadLevelBackgroundData_RenderGround_Horizontal:
+	; Increment the column.
 	INC byte_RAM_E5
 	LDA byte_RAM_E5
 	CMP #$10
-	BNE loc_BANK6_97AC
+	BNE ReadLevelBackgroundData_RenderGround_CheckComplete
 
+	; Increment the page and reset to the first column.
 	INC byte_RAM_E8
 	LDA #$00
 	STA byte_RAM_E5
-	JMP loc_BANK6_97AC
+	JMP ReadLevelBackgroundData_RenderGround_CheckComplete
 
-; ---------------------------------------------------------------------------
 
-loc_BANK6_97A7:
+ReadLevelBackgroundData_RenderGround_Vertical:
+	; Increment the row.
 	LDA #$10
 	JSR UpdateAreaYOffset
 
-loc_BANK6_97AC:
+ReadLevelBackgroundData_RenderGround_CheckComplete:
+	; If there are more pages to render with this ground setting, keep going.
 	LDA byte_RAM_E8
 	CMP byte_RAM_540
-	BNE loc_BANK6_978C
+	BNE ReadLevelBackgroundData_RenderGround
 
 	LDA IsHorizontalLevel
-	BEQ loc_BANK6_97BF
+	BEQ ReadLevelBackgroundData_RenderGround_CheckComplete_Vertical
 
+ReadLevelBackgroundData_RenderGround_CheckComplete_Horizontal:
+	; If there is more to render with this ground setting, keep going.
 	LDA byte_RAM_E5
 	CMP byte_RAM_E
-	BCC loc_BANK6_978C
+	BCC ReadLevelBackgroundData_RenderGround
 
-	BCS loc_BANK6_97C5
+	; Otherwise, move on and process the next object.
+	BCS ReadLevelBackgroundData_RenderGround_Exit
 
-loc_BANK6_97BF:
+ReadLevelBackgroundData_RenderGround_CheckComplete_Vertical:
 	LDA byte_RAM_E6
 	CMP byte_RAM_E
-	BCC loc_BANK6_978C
+	BCC ReadLevelBackgroundData_RenderGround
 
-loc_BANK6_97C5:
+ReadLevelBackgroundData_RenderGround_Exit:
 	LDA (byte_RAM_5), Y
+	; Encountering `$FF` indicates the end of the level data.
 	CMP #$FF
 	BEQ ReadGroundSetByte_Exit
 
+	; Otherwise this was triggered because we encountered a ground setting object, so `GroundSetting`
+	; for the next time we need to render the ground.
 	INY
 	LDA (byte_RAM_5), Y
 	AND #$1F
 	STA GroundSetting
-	JMP loc_BANK6_9770
+	JMP ReadLevelBackgroundData_ProcessObject_AdvanceByte
 
-; End of function sub_BANK6_9728
 
-; =============== S U B R O U T I N E =======================================
-
-; Input
-;   X = Ground set offset
+;
+; Reads the current ground setting byte.
+;
+; ##### Input
+; - `X`: Ground setting offset
+;
+; ##### Output
+; - `A`: Byte containing the 4 ground appearance bit pairs for the offset
+;
 ReadGroundSetByte:
 	LDA IsHorizontalLevel
 	BNE ReadGroundSetByte_Vertical
@@ -4417,10 +4682,15 @@ ReadGroundSetByte_Vertical:
 ReadGroundSetByte_Exit:
 	RTS
 
-; End of function ReadGroundSetByte
 
-; =============== S U B R O U T I N E =======================================
-
+;
+; Draws the current ground setting and type to the raw tile buffer.
+;
+; ##### Input
+; - `GroundSetting`: current ground setting
+; - `GroundType`: current ground appearance
+; - `byte_RAM_E7`: tile placement offset
+;
 LoadGroundSetData:
 	STY byte_RAM_4
 	LDA GroundSetting
@@ -4465,7 +4735,7 @@ LoadGroundSetData_Exit:
 	RTS
 
 ;
-; Draws current ground set tiles
+; Draws current ground set tiles.
 ;
 WriteGroundSetTiles:
 WriteGroundSetTiles1:
@@ -4483,7 +4753,7 @@ WriteGroundSetTiles3:
 WriteGroundSetTiles4:
 	AND #$03
 	STX byte_RAM_3
-	; This BEQ is what effectively ignores the first index of the groundset tiles lookup tables.
+	; This `BEQ` is what effectively ignores the first index of the groundset tiles lookup tables.
 	BEQ WriteGroundSetTiles_AfterWriteTile
 
 	CLC
@@ -4551,14 +4821,15 @@ ReadGroundTileVertical:
 ;
 ; Updates the area page and tile placement offset
 ;
-; Input
-;   byte_RAM_E8 = area page
-;   byte_RAM_E5 = tile placement offset shift
-;   byte_RAM_E6 = previous tile placement offset
-; Output
-;   RAM_1 = low byte of decoded level data RAM
-;   RAM_2 = low byte of decoded level data RAM
-;   byte_RAM_E7 = target tile placement offset
+; ##### Input
+; - `byte_RAM_E8`: area page
+; - `byte_RAM_E5`: tile placement offset shift
+; - `byte_RAM_E6`: previous tile placement offset
+;
+; ##### Output
+; - `byte_RAM_1`: low byte of decoded level data RAM
+; - `byte_RAM_2`: low byte of decoded level data RAM
+; - `byte_RAM_E7`: target tile placement offset
 ;
 SetTileOffsetAndAreaPageAddr_Bank6:
 	LDX byte_RAM_E8
@@ -4573,11 +4844,12 @@ SetTileOffsetAndAreaPageAddr_Bank6:
 ;
 ; Updates the area page that we're drawing tiles to
 ;
-; Input
-;   X = area page
-; Output
-;   byte_RAM_1 = low byte of decoded level data RAM
-;   byte_RAM_2 = low byte of decoded level data RAM
+; ##### Input
+; - `X`: area page
+;
+; ##### Output
+; - `byte_RAM_1`: low byte of decoded level data RAM
+; - `byte_RAM_2`: low byte of decoded level data RAM
 ;
 SetAreaPageAddr_Bank6:
 	LDA DecodedLevelPageStartLo_Bank6, X
@@ -4654,38 +4926,61 @@ LevelParser_EatDoorPointer:
 	RTS
 ENDIF
 
-; ---------------------------------------------------------------------------
-unk_BANK6_98DA:
-	.db $28
-	.db $24
-; =============== S U B R O U T I N E =======================================
+;
+; High byte of the PPU scroll offset for nametable B.
+;
+; When mirroring vertically, nametable A is `$2000` and nametable B is `$2800`.
+; When mirroring horizontally, nametable A is `$2000` and nametable B is `$2400`.
+;
+PPUScrollHiOffsets_Bank6:
+	.db $28 ; vertical
+	.db $24 ; horizontal
 
-sub_BANK6_98DC:
+;
+; Resets the PPU high scrolling values and sets the high byte of the PPU scroll offset.
+;
+; The version of the subroutine in this bank is always called with `A = $00`.
+;
+; ##### Input
+; - `A`: 0 = use nametable A, 1 = use nametable B
+; - `Y`: 0 = vertical, 1 = horizontal
+;
+; ##### Output
+; - `PPUScrollYHiMirror`
+; - `PPUScrollXHiMirror`
+; - `byte_RAM_506`: PPU scroll offset high byte
+;
+ResetPPUScrollHi_Bank6:
 	LSR A
-	BCS loc_BANK6_98EA
+	BCS ResetPPUScrollHi_NametableB_Bank6
 
+ResetPPUScrollHi_NametableA_Bank6:
 	LDA #$01
-	STA byte_RAM_C9
+	STA PPUScrollXHiMirror
 	ASL A
-	STA byte_RAM_C8
+	STA PPUScrollYHiMirror
 	LDA #$20
-	BNE loc_BANK6_98F3
+	BNE ResetPPUScrollHi_Exit_Bank6
 
-loc_BANK6_98EA:
+ResetPPUScrollHi_NametableB_Bank6:
 	LDA #$00
-	STA byte_RAM_C9
-	STA byte_RAM_C8
-	LDA unk_BANK6_98DA, Y
+	STA PPUScrollXHiMirror
+	STA PPUScrollYHiMirror
+	LDA PPUScrollHiOffsets_Bank6, Y
 
-loc_BANK6_98F3:
+ResetPPUScrollHi_Exit_Bank6:
 	STA byte_RAM_506
 	RTS
 
-; End of function sub_BANK6_98DC
 
-; =============== S U B R O U T I N E =======================================
-
-CreateMushroomObject:
+;
+; Creates a mushroom object in subspace.
+;
+; ##### Input
+; - `X`: Object position
+; - `Y`: Which mushroom (0 or 1)
+;
+CreateSubspaceMushroomObject:
 	TXA
 	PHA
 	AND #$F0
@@ -4696,16 +4991,25 @@ CreateMushroomObject:
 	ASL A
 	ASL A
 	STA ObjectXLo
+
+	; Subspace is page `$0A`.
 	LDA #$0A
 	STA ObjectXHi
 	LDX #$00
 	STX byte_RAM_12
 	STX ObjectYHi
+
+	; Create a living fungus.
+	; Even most of this routine uses an enemy slot offset, the next few lines assume slot 0.
+	; We just set `X` to 0, so this is a safe enough assumption.
 	LDA #Enemy_Mushroom
 	STA ObjectType
-	LDA #$01
+	LDA #EnemyState_Alive
 	STA EnemyState
+	; Keep track of which mushroom so that you can't collect it twice.
 	STY EnemyVariable
+
+	; Reset various object timers and attributes
 	LDA #$00
 	STA EnemyTimer, X
 	STA EnemyArray_B1, X
@@ -4718,6 +5022,8 @@ CreateMushroomObject:
 	STA EnemyArray_45C, X
 	STA ObjectYVelocity, X
 	STA ObjectXVelocity, X
+
+	; Load various object attributes for a mushroom
 	LDY ObjectType, X
 	LDA ObjectAttributeTable, Y
 	AND #$7F
@@ -4729,7 +5035,10 @@ CreateMushroomObject:
 	LDA EnemyArray_492_Data, Y
 	STA EnemyArray_492, X
 	LDA #$FF
-	STA unk_RAM_441, X
+	STA EnemyRawDataOffset, X
+
+	; Restore X to its previous value
 	PLA
 	TAX
+
 	RTS

--- a/src/prg-6-7.asm
+++ b/src/prg-6-7.asm
@@ -1150,7 +1150,7 @@ FindClimableTile_LoadReplacement:
 	RTS
 
 ;
-; Creates a climbable tile that you can stand on based on `ObjectTypeAXthruFX`.
+; Creates a climbable tile that you can stand on based on ObjectTypeAXthruFX
 ;
 ; ##### Output
 ; - `A`: tile that was written
@@ -1464,14 +1464,6 @@ CreateObject_VerticalBlocks:
 	LDY byte_RAM_E7
 
 IFNDEF LEVEL_ENGINE_UPGRADES
-;
-; This little hack is used to show the pile of rocks behind ClawGrip in his boss
-; room. If we're currently in 5-2, area 5, the vertical rock wall with an angled
-; top is replaced by ClawGrip's rocks instead.
-;
-; The level/area check is important! If you go into one of the duplicates of the
-; boss room, you'll see the angled rock wall instead.
-;
 	LDA byte_RAM_50E
 	CMP #$06
 	BNE CreateObject_VerticalBlocks_NotClawGrip

--- a/src/prg-6-7.asm
+++ b/src/prg-6-7.asm
@@ -3634,7 +3634,7 @@ loc_BANK6_9439:
 	SEC
 
 	SBC ScreenBoundaryLeftLo
-	STA CameraVelocityX
+	STA MoveCameraX
 	PLA
 	LSR A
 	LSR A

--- a/src/prg-6-7.asm
+++ b/src/prg-6-7.asm
@@ -3451,7 +3451,7 @@ ResetLevelData_Loop:
 	STA ScreenYLo
 	STA ScreenBoundaryLeftHi
 	STA ScreenBoundaryLeftLo
-	STA_abs NeedVerticalScroll
+	STA_abs NeedsScroll
 	RTS
 
 
@@ -3634,7 +3634,7 @@ loc_BANK6_9439:
 	SEC
 
 	SBC ScreenBoundaryLeftLo
-	STA byte_RAM_BA
+	STA CameraVelocityX
 	PLA
 	LSR A
 	LSR A

--- a/src/prg-6-7.asm
+++ b/src/prg-6-7.asm
@@ -5048,7 +5048,7 @@ PPUScrollHiOffsets_Bank6:
 ; ##### Output
 ; - `PPUScrollYHiMirror`
 ; - `PPUScrollXHiMirror`
-; - `byte_RAM_506`: PPU scroll offset high byte
+; - `PPUScrollCheckHi`: PPU scroll offset high byte
 ;
 ResetPPUScrollHi_Bank6:
 	LSR A
@@ -5069,7 +5069,7 @@ ResetPPUScrollHi_NametableB_Bank6:
 	LDA PPUScrollHiOffsets_Bank6, Y
 
 ResetPPUScrollHi_Exit_Bank6:
-	STA byte_RAM_506
+	STA PPUScrollCheckHi
 	RTS
 
 

--- a/src/prg-a-b.asm
+++ b/src/prg-a-b.asm
@@ -465,6 +465,7 @@ loc_BANKA_8493:
 	CPY #$FF
 	BNE loc_BANKA_8493
 
+	; This data is copied, but doesn't appear to be used. Its original purpose is not obvious.
 	LDY #$17
 loc_BANKA_84A0:
 	LDA MysteryData14439, Y
@@ -472,6 +473,7 @@ loc_BANKA_84A0:
 	DEY
 	BPL loc_BANKA_84A0
 
+	; Copy object collision hitbox table
 	LDY #$4F
 loc_BANKA_84AB:
 	LDA byte_BANKF_F099, Y
@@ -479,6 +481,7 @@ loc_BANKA_84AB:
 	DEY
 	BPL loc_BANKA_84AB
 
+	; Copy flying carpet acceleration table
 	LDY #$03
 loc_BANKA_84B6:
 	LDA byte_BANKA_84E1, Y
@@ -486,7 +489,7 @@ loc_BANKA_84B6:
 	DEY
 	BPL loc_BANKA_84B6
 
-	; Collision data
+	; Copy object collision type table
 	LDY #$49
 loc_BANKA_84C1:
 	LDA byte_BANKF_F607, Y
@@ -494,6 +497,10 @@ loc_BANKA_84C1:
 	DEY
 	BPL loc_BANKA_84C1
 
+	; Copy end of level door PPU data to RAM
+	;
+	; The fact that it's in RAM is actually taken advantage of when defeating Clawgrip, since the
+	; door needs to be drawn in a slightly different spot.
 	LDY #$20
 loc_BANKA_84CC:
 	LDA EndOfLevelDoor, Y
@@ -501,6 +508,7 @@ loc_BANKA_84CC:
 	DEY
 	BPL loc_BANKA_84CC
 
+	; Copy Wart's OAM address table
 	LDY #$06
 loc_BANKA_84D7:
 	LDA byte_BANKA_84E5, Y
@@ -510,23 +518,23 @@ loc_BANKA_84D7:
 
 	RTS
 
-; End of function CopyCharacterStatsAndStuff
 
-; ---------------------------------------------------------------------------
+; Flying carpet acceleration
 byte_BANKA_84E1:
 	.db $00
 	.db $01
 	.db $FF
 	.db $00
 
+; Wart OAM address offsets
 byte_BANKA_84E5:
 	.db $00
 	.db $E0
-	.db $FF
+	.db $FF ; Cycled in code ($7267)
 	.db $D0
 	.db $00
 	.db $E0
-	.db $FF
+	.db $FF ; Cycled in code ($726B)
 
 PlayerSelectPalettes:
 	.db $3F, $00, $20

--- a/src/prg-a-b.asm
+++ b/src/prg-a-b.asm
@@ -476,8 +476,8 @@ loc_BANKA_84A0:
 	; Copy object collision hitbox table
 	LDY #$4F
 loc_BANKA_84AB:
-	LDA byte_BANKF_F099, Y
-	STA unk_RAM_7100, Y
+	LDA ObjectCollisionHitboxLeft, Y
+	STA ObjectCollisionHitboxLeft_RAM, Y
 	DEY
 	BPL loc_BANKA_84AB
 

--- a/src/prg-c-d.asm
+++ b/src/prg-c-d.asm
@@ -47,9 +47,9 @@ sub_BANKC_801C:
 	STA RAM_PPUDataBufferPointer
 	LDA MarioDream_Pointers + 1, X
 	STA RAM_PPUDataBufferPointer + 1
-	LDA #0
-	STA NMIWaitFlag
 
+	LDA #$00
+	STA NMIWaitFlag
 loc_BANKC_802E:
 	LDA NMIWaitFlag
 	BPL loc_BANKC_802E

--- a/src/prg-e-f.asm
+++ b/src/prg-e-f.asm
@@ -2854,10 +2854,10 @@ VerticalTileCollisionHitboxX:
 ;
 ; Each bounding box entry is four bytes:
 ;
-;   1. upper boundary
-;   2. upper boundary
-;   3. lower boundary
-;   4. lower boundary
+;   1. upper boundary (upward velocity)
+;   2. lower boundary (upward velocity)
+;   3. upper boundary (downward velocity)
+;   4. lower boundary (downward velocity)
 ;
 ; Not totally sure why there are two bytes, but it seems to have something to do with the direction
 ; of movement when checking the collision.

--- a/src/prg-e-f.asm
+++ b/src/prg-e-f.asm
@@ -653,8 +653,8 @@ loc_BANKF_E2B2:
 	STA PreviousCharacter
 	LDA CurrentWorld
 	STA PreviousWorld
-	LDY #$3F
 
+	LDY #$3F
 loc_BANKF_E2CA:
 	LDA PlayerSelectMarioSprites1, Y
 	STA SpriteDMAArea + $10, Y
@@ -2722,7 +2722,6 @@ ChangeCHRBanks_FME7:
 	LDY #$03
 ChangeCHRBanks_FME7_Loop:
 	TYA
-	ORA #$80
 	STA $8000
 	LDA SpriteCHR1, Y
 	STA $A000

--- a/src/prg-e-f.asm
+++ b/src/prg-e-f.asm
@@ -3078,7 +3078,7 @@ RunFrame_Horizontal:
 	JSR HandlePlayerState
 
 RunFrame_Horizontal_AfterPlayerState:
-	JSR GetCameraVelocityX
+	JSR GetMoveCameraX
 
 	JSR ApplyHorizontalScroll
 
@@ -3400,10 +3400,10 @@ SetPlayerScreenPosition_DoClimbingTransition:
 ; Calculate the x-velocity of the camera based on the distance between the player
 ; and the center of the screen.
 ;
-GetCameraVelocityX:
+GetMoveCameraX:
 	LDA #$00
 	LDY ScrollXLock
-	BNE GetCameraVelocityX_Exit
+	BNE GetMoveCameraX_Exit
 
 	LDA PlayerXLo
 	SEC
@@ -3411,8 +3411,8 @@ GetCameraVelocityX:
 	SEC
 	SBC ScreenBoundaryLeftLo
 
-GetCameraVelocityX_Exit:
-	STA CameraVelocityX
+GetMoveCameraX_Exit:
+	STA MoveCameraX
 	RTS
 
 

--- a/src/prg-e-f.asm
+++ b/src/prg-e-f.asm
@@ -2789,32 +2789,34 @@ unusedSpace $F000, $FF
 
 
 ;
+; ## Tile collision bounding boxes
+;
+; These hitboxes are used when determining the collision between objects and background tiles.
+;
 ; Tile collision bounding box table offsets
 ;
-byte_BANKF_F000:
-	.db $00 ; 0x0 ; player standing
-	.db $08 ; ?? ; player holding item
-	.db $10 ; ?? ; player ducking
-	.db $18 ; ?? ; player ducking with item
-	.db $20 ; most 16x16 items, clips in 1px
-	.db $24 ; most 16x16 enemies, clips in 4px
-byte_BANKF_F006:
-	.db $28
-	.db $2A
-	.db $29
-	.db $2B
-byte_BANKF_F00A:
-	.db $2C
-byte_BANKF_F00B:
-	.db $2E
-	.db $30 ; 16x32 enemies, clips in 4px (birdo, mouser)
-	.db $34 ; bullet, clips in 8px
-	.db $38 ; 16x48 enemies, clips in 4px (tryclde)
-	.db $3C ; spark, clips in 0px
-	.db $40 ; flying carpet
+TileCollisionHitboxIndex:
+	.db $00 ; $00 - player standing
+	.db $08 ; $01 - player holding item
+	.db $10 ; $02 - player ducking
+	.db $18 ; $03 - player ducking with item
+	.db $20 ; $04 - 16x16 items (vegetables, etc.)
+	.db $24 ; $05 - 16x16 enemies (shyguy, etc.)
+; The following four entries are used to determine whether a carried item can be thrown.
+	.db $28 ; $06 - player left, standing
+	.db $2A ; $07 - player left, ducking
+	.db $29 ; $08 - player right, standing
+	.db $2B ; $09 - player right, ducking
+	.db $2C ; $0A - player climb/cherry
+	.db $2E ; $0B - player climbing
+	.db $30 ; $0C - 16x32 enemies (birdo, mouser)
+	.db $34 ; $0D - projectile
+	.db $38 ; $0E - 16x48 enemies (tryclde)
+	.db $3C ; $0F - spark
+	.db $40 ; $10 - flying carpet
 
 ;
-; Tile vertical collision bounding box (x-offsets)
+; ### Tile vertical collision bounding box (x-offsets)
 ;
 ; The left boundary offset is measured from the left side of the sprite.
 ; The right boundary offset is measured from the right of the first tile of the sprite.
@@ -2827,26 +2829,26 @@ byte_BANKF_F00B:
 ;   4. right boundary (downward velocity)
 ;
 VerticalTileCollisionHitboxX:
-	.db $06,$09,$06,$09 ; $00
-	.db $01,$01,$0E,$0E ; $04
-	.db $06,$09,$06,$09 ; $08
-	.db $01,$01,$0E,$0E ; $0C
-	.db $06,$09,$06,$09 ; $10
-	.db $01,$01,$0E,$0E ; $14
-	.db $06,$09,$06,$09 ; $18
-	.db $01,$01,$0E,$0E ; $1C
-	.db $08,$08,$00,$0F ; $20
-	.db $08,$08,$03,$0C ; $24
-	.db $F8,$18,$F8,$18 ; $28
-	.db $08,$08,$08,$08 ; $2C
-	.db $08,$08,$03,$0C ; $30
-	.db $03,$03,$02,$05 ; $34
-	.db $08,$08,$03,$0C ; $38
-	.db $08,$08,$FF,$10 ; $3C
-	.db $10,$10,$02,$1E ; $40
+	.db $06, $09, $06, $09 ; $00
+	.db $01, $01, $0E, $0E ; $04
+	.db $06, $09, $06, $09 ; $08
+	.db $01, $01, $0E, $0E ; $0C
+	.db $06, $09, $06, $09 ; $10
+	.db $01, $01, $0E, $0E ; $14
+	.db $06, $09, $06, $09 ; $18
+	.db $01, $01, $0E, $0E ; $1C
+	.db $08, $08, $00, $0F ; $20
+	.db $08, $08, $03, $0C ; $24
+	.db $F8, $18, $F8, $18 ; $28
+	.db $08, $08, $08, $08 ; $2C
+	.db $08, $08, $03, $0C ; $30
+	.db $03, $03, $02, $05 ; $34
+	.db $08, $08, $03, $0C ; $38
+	.db $08, $08, $FF, $10 ; $3C
+	.db $10, $10, $02, $1E ; $40
 
 ;
-; Tile vertical collision bounding box (y-offsets)
+; ### Tile vertical collision bounding box (y-offsets)
 ;
 ; The upper and lower boundary offset are measured from the top of the sprite.
 ;
@@ -2861,50 +2863,117 @@ VerticalTileCollisionHitboxX:
 ; of movement when checking the collision.
 ;
 VerticalTileCollisionHitboxY:
-	.db $07,$07,$20,$20 ; $00
-	.db $0D,$1C,$0D,$1C ; $04
-	.db $FF,$FF,$20,$20 ; $08
-	.db $04,$1C,$04,$1C ; $0C
-	.db $0F,$0F,$20,$20 ; $10
-	.db $1C,$1C,$1C,$1C ; $14
-	.db $07,$07,$20,$20 ; $18
-	.db $0D,$1C,$0D,$1C ; $1C
-	.db $00,$10,$09,$09 ; $20
-	.db $03,$10,$09,$09 ; $24
-	.db $FF,$FF,$0F,$0F ; $28
-	.db $0C,$14,$07,$20 ; $2C
-	.db $FE,$20,$10,$10 ; $30
-	.db $09,$0A,$08,$08 ; $34
-	.db $03,$30,$18,$18 ; $38
-	.db $FF,$10,$08,$08 ; $3C
-	.db $09,$0A,$08,$08 ; $40
+	.db $07, $07, $20, $20 ; $00
+	.db $0D, $1C, $0D, $1C ; $04
+	.db $FF, $FF, $20, $20 ; $08
+	.db $04, $1C, $04, $1C ; $0C
+	.db $0F, $0F, $20, $20 ; $10
+	.db $1C, $1C, $1C, $1C ; $14
+	.db $07, $07, $20, $20 ; $18
+	.db $0D, $1C, $0D, $1C ; $1C
+	.db $00, $10, $09, $09 ; $20
+	.db $03, $10, $09, $09 ; $24
+	.db $FF, $FF, $0F, $0F ; $28
+	.db $0C, $14, $07, $20 ; $2C
+	.db $FE, $20, $10, $10 ; $30
+	.db $09, $0A, $08, $08 ; $34
+	.db $03, $30, $18, $18 ; $38
+	.db $FF, $10, $08, $08 ; $3C
+	.db $09, $0A, $08, $08 ; $40
 
 ;
-; Object vertical collision bounding box
+; ## Object vertical collision bounding box
 ;
-; (copied to unk_RAM_7100)
+; These hitboxes are copied to RAM and used when determining collision between objects. This allows
+; the hitboxes to change dynamically, which is used when Hawkmouth (offset $0B) opens and closes.
 ;
-byte_BANKF_F099:
-	.db $02,$02,$03,$00 ; $00
-	.db $03,$03,$F8,$00 ; $04
-	.db $03,$01,$F3,$04 ; $08
-	.db $03,$03,$03,$F2 ; $0C
-	.db $03,$03,$05,$03 ; $10
-	.db $0B,$10,$03,$00 ; $14, shy guy y?
-	.db $03,$03,$F8,$00 ; $18
-	.db $09,$04,$03,$03 ; $1C
-	.db $0E,$03,$03,$03 ; $20
-	.db $F6,$0C,$02,$03 ; $24
-	.db $0B,$0B,$09,$10 ; $28, shy guy x?
-	.db $09,$19,$20,$20 ; $2C
-	.db $03,$1E,$19,$08 ; $30
-	.db $09,$09,$09,$18 ; $34
-	.db $09,$1A,$06,$15 ; $38
-	.db $16,$11,$0D,$10 ; $3C
-	.db $1A,$19,$24,$10 ; $40
-	.db $03,$04,$2D,$30 ; $44
-	.db $0F,$2E,$3E,$1E ; $48
-	.db $28,$13,$48,$26 ; $4C
+ObjectCollisionHitboxLeft:
+	.db $02 ; $00
+	.db $02 ; $01
+	.db $03 ; $02
+	.db $00 ; $03
+	.db $03 ; $04
+	.db $03 ; $05
+	.db $F8 ; $06
+	.db $00 ; $07
+	.db $03 ; $08
+	.db $01 ; $09
+	.db $F3 ; $0A
+	.db $04 ; $0B
+	.db $03 ; $0C
+	.db $03 ; $0D
+	.db $03 ; $0E
+	.db $F2 ; $0F
+	.db $03 ; $10
+	.db $03 ; $11
+	.db $05 ; $12
+	.db $03 ; $13
+
+ObjectCollisionHitboxTop:
+	.db $0B ; $00
+	.db $10 ; $01
+	.db $03 ; $02
+	.db $00 ; $03
+	.db $03 ; $04
+	.db $03 ; $05
+	.db $F8 ; $06
+	.db $00 ; $07
+	.db $09 ; $08
+	.db $04 ; $09
+	.db $03 ; $0A
+	.db $03 ; $0B
+	.db $0E ; $0C
+	.db $03 ; $0D
+	.db $03 ; $0E
+	.db $03 ; $0F
+	.db $F6 ; $10
+	.db $0C ; $11
+	.db $02 ; $12
+	.db $03 ; $13
+
+ObjectCollisionHitboxRight:
+	.db $0B ; $00
+	.db $0B ; $01
+	.db $09 ; $02
+	.db $10 ; $03
+	.db $09 ; $04
+	.db $19 ; $05
+	.db $20 ; $06
+	.db $20 ; $07
+	.db $03 ; $08
+	.db $1E ; $09
+	.db $19 ; $0A
+	.db $08 ; $0B
+	.db $09 ; $0C
+	.db $09 ; $0D
+	.db $09 ; $0E
+	.db $18 ; $0F
+	.db $09 ; $10
+	.db $1A ; $11
+	.db $06 ; $12
+	.db $15 ; $13
+
+ObjectCollisionHitboxBottom:
+	.db $16 ; $00
+	.db $11 ; $01
+	.db $0D ; $02
+	.db $10 ; $03
+	.db $1A ; $04
+	.db $19 ; $05
+	.db $24 ; $06
+	.db $10 ; $07
+	.db $03 ; $08
+	.db $04 ; $09
+	.db $2D ; $0A
+	.db $30 ; $0B
+	.db $0F ; $0C
+	.db $2E ; $0D
+	.db $3E ; $0E
+	.db $1E ; $0F
+	.db $28 ; $10
+	.db $13 ; $11
+	.db $48 ; $12
+	.db $26 ; $13
 
 
 NextSpriteFlickerSlot:
@@ -3966,7 +4035,7 @@ EnemyArray_46E_Data:
 	.db %00000100 ; $46 Enemy_Stopwatch
 
 ;
-; Height and horizontal collision detection
+; Index for tile collision bounding box table
 ;
 EnemyArray_492_Data:
 	.db $00 ; $00 Enemy_Heart
@@ -4042,154 +4111,154 @@ EnemyArray_492_Data:
 	.db $05 ; $46 Enemy_Stopwatch
 
 ;
-; Horizontal hitbox, collision detection, and carried height
+; Index for object collision bounding box table
 ;
 EnemyArray_489_Data:
-	.db $08 ; $00Enemy_Heart
-	.db $02 ; $01Enemy_ShyguyRed
-	.db $02 ; $02Enemy_Tweeter
-	.db $02 ; $03Enemy_ShyguyPink
-	.db $02 ; $04Enemy_Porcupo
-	.db $02 ; $05Enemy_SnifitRed
-	.db $02 ; $06Enemy_SnifitGray
-	.db $02 ; $07Enemy_SnifitPink
-	.db $04 ; $08Enemy_Ostro
-	.db $02 ; $09Enemy_BobOmb
-	.db $09 ; $0AEnemy_AlbatossCarryingBobOmb
-	.db $09 ; $0BEnemy_AlbatossStartRight
-	.db $09 ; $0CEnemy_AlbatossStartLeft
-	.db $02 ; $0DEnemy_NinjiRunning
-	.db $02 ; $0EEnemy_NinjiJumping
-	.db $02 ; $0FEnemy_BeezoDiving
-	.db $02 ; $10Enemy_BeezoStraight
-	.db $02 ; $11Enemy_WartBubble
-	.db $02 ; $12Enemy_Pidgit
-	.db $02 ; $13Enemy_Trouter
-	.db $02 ; $14Enemy_Hoopstar
-	.db $08 ; $15Enemy_JarGeneratorShyguy
-	.db $08 ; $16Enemy_JarGeneratorBobOmb
-	.db $02 ; $17Enemy_Phanto
-	.db $04 ; $18Enemy_CobratJar
-	.db $04 ; $19Enemy_CobratSand
-	.db $0E ; $1AEnemy_Pokey
-	.db $08 ; $1BEnemy_Bullet
-	.db $04 ; $1CEnemy_Birdo
-	.db $04 ; $1DEnemy_Mouser
-	.db $02 ; $1EEnemy_Egg
-	.db $0F ; $1FEnemy_Tryclyde
-	.db $02 ; $20Enemy_Fireball
-	.db $13 ; $21Enemy_Clawgrip
-	.db $02 ; $22Enemy_ClawgripRock
-	.db $02 ; $23Enemy_PanserStationaryFiresAngled
-	.db $02 ; $24Enemy_PanserWalking
-	.db $02 ; $25Enemy_PanserStationaryFiresUp
-	.db $10 ; $26Enemy_Autobomb
-	.db $02 ; $27Enemy_AutobombFire
-	.db $12 ; $28Enemy_WhaleSpout
-	.db $02 ; $29Enemy_Flurry
-	.db $0F ; $2AEnemy_Fryguy
-	.db $02 ; $2BEnemy_FryguySplit
-	.db $11 ; $2CEnemy_Wart
-	.db $0B ; $2DEnemy_HawkmouthBoss
-	.db $02 ; $2EEnemy_Spark1
-	.db $02 ; $2FEnemy_Spark2
-	.db $02 ; $30Enemy_Spark3
-	.db $02 ; $31Enemy_Spark4
-	.db $02 ; $32Enemy_VegetableSmall
-	.db $02 ; $33Enemy_VegetableLarge
-	.db $02 ; $34Enemy_VegetableWart
-	.db $02 ; $35Enemy_Shell
-	.db $02 ; $36Enemy_Coin
-	.db $02 ; $37Enemy_Bomb
-	.db $04 ; $38Enemy_Rocket
-	.db $03 ; $39Enemy_MushroomBlock
-	.db $03 ; $3AEnemy_POWBlock
-	.db $07 ; $3BEnemy_FallingLogs
-	.db $04 ; $3CEnemy_SubspaceDoor
-	.db $03 ; $3DEnemy_Key
-	.db $03 ; $3EEnemy_SubspacePotion
-	.db $03 ; $3FEnemy_Mushroom
-	.db $03 ; $40Enemy_Mushroom1up
-	.db $09 ; $41Enemy_FlyingCarpet
-	.db $0B ; $42Enemy_HawkmouthRight
-	.db $0B ; $43Enemy_HawkmouthLeft
-	.db $02 ; $44Enemy_CrystalBall
-	.db $02 ; $45Enemy_Starman
-	.db $02 ; $46Enemy_Stopwatch
+	.db $08 ; $00 Enemy_Heart
+	.db $02 ; $01 Enemy_ShyguyRed
+	.db $02 ; $02 Enemy_Tweeter
+	.db $02 ; $03 Enemy_ShyguyPink
+	.db $02 ; $04 Enemy_Porcupo
+	.db $02 ; $05 Enemy_SnifitRed
+	.db $02 ; $06 Enemy_SnifitGray
+	.db $02 ; $07 Enemy_SnifitPink
+	.db $04 ; $08 Enemy_Ostro
+	.db $02 ; $09 Enemy_BobOmb
+	.db $09 ; $0A Enemy_AlbatossCarryingBobOmb
+	.db $09 ; $0B Enemy_AlbatossStartRight
+	.db $09 ; $0C Enemy_AlbatossStartLeft
+	.db $02 ; $0D Enemy_NinjiRunning
+	.db $02 ; $0E Enemy_NinjiJumping
+	.db $02 ; $0F Enemy_BeezoDiving
+	.db $02 ; $10 Enemy_BeezoStraight
+	.db $02 ; $11 Enemy_WartBubble
+	.db $02 ; $12 Enemy_Pidgit
+	.db $02 ; $13 Enemy_Trouter
+	.db $02 ; $14 Enemy_Hoopstar
+	.db $08 ; $15 Enemy_JarGeneratorShyguy
+	.db $08 ; $16 Enemy_JarGeneratorBobOmb
+	.db $02 ; $17 Enemy_Phanto
+	.db $04 ; $18 Enemy_CobratJar
+	.db $04 ; $19 Enemy_CobratSand
+	.db $0E ; $1A Enemy_Pokey
+	.db $08 ; $1B Enemy_Bullet
+	.db $04 ; $1C Enemy_Birdo
+	.db $04 ; $1D Enemy_Mouser
+	.db $02 ; $1E Enemy_Egg
+	.db $0F ; $1F Enemy_Tryclyde
+	.db $02 ; $20 Enemy_Fireball
+	.db $13 ; $21 Enemy_Clawgrip
+	.db $02 ; $22 Enemy_ClawgripRock
+	.db $02 ; $23 Enemy_PanserStationaryFiresAngled
+	.db $02 ; $24 Enemy_PanserWalking
+	.db $02 ; $25 Enemy_PanserStationaryFiresUp
+	.db $10 ; $26 Enemy_Autobomb
+	.db $02 ; $27 Enemy_AutobombFire
+	.db $12 ; $28 Enemy_WhaleSpout
+	.db $02 ; $29 Enemy_Flurry
+	.db $0F ; $2A Enemy_Fryguy
+	.db $02 ; $2B Enemy_FryguySplit
+	.db $11 ; $2C Enemy_Wart
+	.db $0B ; $2D Enemy_HawkmouthBoss
+	.db $02 ; $2E Enemy_Spark1
+	.db $02 ; $2F Enemy_Spark2
+	.db $02 ; $30 Enemy_Spark3
+	.db $02 ; $31 Enemy_Spark4
+	.db $02 ; $32 Enemy_VegetableSmall
+	.db $02 ; $33 Enemy_VegetableLarge
+	.db $02 ; $34 Enemy_VegetableWart
+	.db $02 ; $35 Enemy_Shell
+	.db $02 ; $36 Enemy_Coin
+	.db $02 ; $37 Enemy_Bomb
+	.db $04 ; $38 Enemy_Rocket
+	.db $03 ; $39 Enemy_MushroomBlock
+	.db $03 ; $3A Enemy_POWBlock
+	.db $07 ; $3B Enemy_FallingLogs
+	.db $04 ; $3C Enemy_SubspaceDoor
+	.db $03 ; $3D Enemy_Key
+	.db $03 ; $3E Enemy_SubspacePotion
+	.db $03 ; $3F Enemy_Mushroom
+	.db $03 ; $40 Enemy_Mushroom1up
+	.db $09 ; $41 Enemy_FlyingCarpet
+	.db $0B ; $42 Enemy_HawkmouthRight
+	.db $0B ; $43 Enemy_HawkmouthLeft
+	.db $02 ; $44 Enemy_CrystalBall
+	.db $02 ; $45 Enemy_Starman
+	.db $02 ; $46 Enemy_Stopwatch
 
 ; More collision (post-throw)
 byte_BANKF_F607:
-	.db $00 ; $00Enemy_Heart
-	.db $00 ; $01Enemy_ShyguyRed
-	.db $00 ; $02Enemy_Tweeter
-	.db $00 ; $03Enemy_ShyguyPink
-	.db $00 ; $04Enemy_Porcupo
-	.db $00 ; $05Enemy_SnifitRed
-	.db $00 ; $06Enemy_SnifitGray
-	.db $00 ; $07Enemy_SnifitPink
-	.db $00 ; $08Enemy_Ostro
-	.db $00 ; $09Enemy_BobOmb
-	.db $00 ; $0AEnemy_AlbatossCarryingBobOmb
-	.db $00 ; $0BEnemy_AlbatossStartRight
-	.db $00 ; $0CEnemy_AlbatossStartLeft
-	.db $00 ; $0DEnemy_NinjiRunning
-	.db $00 ; $0EEnemy_NinjiJumping
-	.db $00 ; $0FEnemy_BeezoDiving
-	.db $00 ; $10Enemy_BeezoStraight
-	.db $00 ; $11Enemy_WartBubble
-	.db $00 ; $12Enemy_Pidgit
-	.db $00 ; $13Enemy_Trouter
-	.db $00 ; $14Enemy_Hoopstar
-	.db $00 ; $15Enemy_JarGeneratorShyguy
-	.db $00 ; $16Enemy_JarGeneratorBobOmb
-	.db $00 ; $17Enemy_Phanto
-	.db $00 ; $18Enemy_CobratJar
-	.db $00 ; $19Enemy_CobratSand
-	.db $00 ; $1AEnemy_Pokey
-	.db $00 ; $1BEnemy_Bullet
-	.db $00 ; $1CEnemy_Birdo
-	.db $00 ; $1DEnemy_Mouser
-	.db $00 ; $1EEnemy_Egg
-	.db $00 ; $1FEnemy_Tryclyde
-	.db $00 ; $20Enemy_Fireball
-	.db $00 ; $21Enemy_Clawgrip
-	.db $00 ; $22Enemy_ClawgripRock
-	.db $00 ; $23Enemy_PanserStationaryFiresAngled
-	.db $00 ; $24Enemy_PanserWalking
-	.db $00 ; $25Enemy_PanserStationaryFiresUp
-	.db $00 ; $26Enemy_Autobomb
-	.db $00 ; $27Enemy_AutobombFire
-	.db $00 ; $28Enemy_WhaleSpout
-	.db $00 ; $29Enemy_Flurry
-	.db $00 ; $2AEnemy_Fryguy
-	.db $00 ; $2BEnemy_FryguySplit
-	.db $00 ; $2CEnemy_Wart
-	.db $00 ; $2DEnemy_HawkmouthBoss
-	.db $00 ; $2EEnemy_Spark1
-	.db $00 ; $2FEnemy_Spark2
-	.db $00 ; $30Enemy_Spark3
-	.db $00 ; $31Enemy_Spark4
-	.db $01 ; $32Enemy_VegetableSmall
-	.db $01 ; $33Enemy_VegetableLarge
-	.db $01 ; $34Enemy_VegetableWart
-	.db $01 ; $35Enemy_Shell
-	.db $02 ; $36Enemy_Coin
-	.db $01 ; $37Enemy_Bomb
-	.db $00 ; $38Enemy_Rocket
-	.db $02 ; $39Enemy_MushroomBlock
-	.db $03 ; $3AEnemy_POWBlock
-	.db $02 ; $3BEnemy_FallingLogs
-	.db $04 ; $3CEnemy_SubspaceDoor
-	.db $02 ; $3DEnemy_Key
-	.db $02 ; $3EEnemy_SubspacePotion
-	.db $02 ; $3FEnemy_Mushroom
-	.db $02 ; $40Enemy_Mushroom1up
-	.db $02 ; $41Enemy_FlyingCarpet
-	.db $02 ; $42Enemy_HawkmouthRight
-	.db $02 ; $43Enemy_HawkmouthLeft
-	.db $02 ; $44Enemy_CrystalBall
-	.db $00 ; $45Enemy_Starman
-	.db $02 ; $46Enemy_Stopwatch
+	.db $00 ; $00 Enemy_Heart
+	.db $00 ; $01 Enemy_ShyguyRed
+	.db $00 ; $02 Enemy_Tweeter
+	.db $00 ; $03 Enemy_ShyguyPink
+	.db $00 ; $04 Enemy_Porcupo
+	.db $00 ; $05 Enemy_SnifitRed
+	.db $00 ; $06 Enemy_SnifitGray
+	.db $00 ; $07 Enemy_SnifitPink
+	.db $00 ; $08 Enemy_Ostro
+	.db $00 ; $09 Enemy_BobOmb
+	.db $00 ; $0A Enemy_AlbatossCarryingBobOmb
+	.db $00 ; $0B Enemy_AlbatossStartRight
+	.db $00 ; $0C Enemy_AlbatossStartLeft
+	.db $00 ; $0D Enemy_NinjiRunning
+	.db $00 ; $0E Enemy_NinjiJumping
+	.db $00 ; $0F Enemy_BeezoDiving
+	.db $00 ; $10 Enemy_BeezoStraight
+	.db $00 ; $11 Enemy_WartBubble
+	.db $00 ; $12 Enemy_Pidgit
+	.db $00 ; $13 Enemy_Trouter
+	.db $00 ; $14 Enemy_Hoopstar
+	.db $00 ; $15 Enemy_JarGeneratorShyguy
+	.db $00 ; $16 Enemy_JarGeneratorBobOmb
+	.db $00 ; $17 Enemy_Phanto
+	.db $00 ; $18 Enemy_CobratJar
+	.db $00 ; $19 Enemy_CobratSand
+	.db $00 ; $1A Enemy_Pokey
+	.db $00 ; $1B Enemy_Bullet
+	.db $00 ; $1C Enemy_Birdo
+	.db $00 ; $1D Enemy_Mouser
+	.db $00 ; $1E Enemy_Egg
+	.db $00 ; $1F Enemy_Tryclyde
+	.db $00 ; $20 Enemy_Fireball
+	.db $00 ; $21 Enemy_Clawgrip
+	.db $00 ; $22 Enemy_ClawgripRock
+	.db $00 ; $23 Enemy_PanserStationaryFiresAngled
+	.db $00 ; $24 Enemy_PanserWalking
+	.db $00 ; $25 Enemy_PanserStationaryFiresUp
+	.db $00 ; $26 Enemy_Autobomb
+	.db $00 ; $27 Enemy_AutobombFire
+	.db $00 ; $28 Enemy_WhaleSpout
+	.db $00 ; $29 Enemy_Flurry
+	.db $00 ; $2A Enemy_Fryguy
+	.db $00 ; $2B Enemy_FryguySplit
+	.db $00 ; $2C Enemy_Wart
+	.db $00 ; $2D Enemy_HawkmouthBoss
+	.db $00 ; $2E Enemy_Spark1
+	.db $00 ; $2F Enemy_Spark2
+	.db $00 ; $30 Enemy_Spark3
+	.db $00 ; $31 Enemy_Spark4
+	.db $01 ; $32 Enemy_VegetableSmall
+	.db $01 ; $33 Enemy_VegetableLarge
+	.db $01 ; $34 Enemy_VegetableWart
+	.db $01 ; $35 Enemy_Shell
+	.db $02 ; $36 Enemy_Coin
+	.db $01 ; $37 Enemy_Bomb
+	.db $00 ; $38 Enemy_Rocket
+	.db $02 ; $39 Enemy_MushroomBlock
+	.db $03 ; $3A Enemy_POWBlock
+	.db $02 ; $3B Enemy_FallingLogs
+	.db $04 ; $3C Enemy_SubspaceDoor
+	.db $02 ; $3D Enemy_Key
+	.db $02 ; $3E Enemy_SubspacePotion
+	.db $02 ; $3F Enemy_Mushroom
+	.db $02 ; $40 Enemy_Mushroom1up
+	.db $02 ; $41 Enemy_FlyingCarpet
+	.db $02 ; $42 Enemy_HawkmouthRight
+	.db $02 ; $43 Enemy_HawkmouthLeft
+	.db $02 ; $44 Enemy_CrystalBall
+	.db $00 ; $45 Enemy_Starman
+	.db $02 ; $46 Enemy_Stopwatch
 
 ; @TODO: use flag
 ; IFNDEF ENABLE_TILE_ATTRIBUTES_TABLE
@@ -4765,6 +4834,12 @@ TileInteractionAttributesTable:
 	.db %00000000 ; $FF
 ENDIF
 
+
+;
+; ### Warp destination lookup table
+;
+; The row is the (0-indexed) world that you're on, the value is the destination.
+;
 WarpDestinations:
 	.db $03
 	.db $01

--- a/src/prg-e-f.asm
+++ b/src/prg-e-f.asm
@@ -2788,12 +2788,14 @@ ENDIF
 unusedSpace $F000, $FF
 
 
-; these seem like they might be pointers, not actual values?
+;
+; Tile collision bounding box table offsets
+;
 byte_BANKF_F000:
-	.db $00 ; 0x0
-	.db $08 ; ??
-	.db $10 ; ??
-	.db $18 ; ??
+	.db $00 ; 0x0 ; player standing
+	.db $08 ; ?? ; player holding item
+	.db $10 ; ?? ; player ducking
+	.db $18 ; ?? ; player ducking with item
 	.db $20 ; most 16x16 items, clips in 1px
 	.db $24 ; most 16x16 enemies, clips in 4px
 byte_BANKF_F006:
@@ -2811,8 +2813,20 @@ byte_BANKF_F00B:
 	.db $3C ; spark, clips in 0px
 	.db $40 ; flying carpet
 
-; collision x bounding box
-byte_BANKF_F011:
+;
+; Tile vertical collision bounding box (x-offsets)
+;
+; The left boundary offset is measured from the left side of the sprite.
+; The right boundary offset is measured from the right of the first tile of the sprite.
+;
+; Each bounding box entry is four bytes:
+;
+;   1. left boundary (upward velocity)
+;   2. right boundary (upward velocity)
+;   3. left boundary (downward velocity)
+;   4. right boundary (downward velocity)
+;
+VerticalTileCollisionHitboxX:
 	.db $06,$09,$06,$09 ; $00
 	.db $01,$01,$0E,$0E ; $04
 	.db $06,$09,$06,$09 ; $08
@@ -2831,8 +2845,22 @@ byte_BANKF_F011:
 	.db $08,$08,$FF,$10 ; $3C
 	.db $10,$10,$02,$1E ; $40
 
-; collision y bounding box
-byte_BANKF_F055:
+;
+; Tile vertical collision bounding box (y-offsets)
+;
+; The upper and lower boundary offset are measured from the top of the sprite.
+;
+; Each bounding box entry is four bytes:
+;
+;   1. upper boundary
+;   2. upper boundary
+;   3. lower boundary
+;   4. lower boundary
+;
+; Not totally sure why there are two bytes, but it seems to have something to do with the direction
+; of movement when checking the collision.
+;
+VerticalTileCollisionHitboxY:
 	.db $07,$07,$20,$20 ; $00
 	.db $0D,$1C,$0D,$1C ; $04
 	.db $FF,$FF,$20,$20 ; $08
@@ -2851,7 +2879,11 @@ byte_BANKF_F055:
 	.db $FF,$10,$08,$08 ; $3C
 	.db $09,$0A,$08,$08 ; $40
 
-; object collision bounding box
+;
+; Object vertical collision bounding box
+;
+; (copied to unk_RAM_7100)
+;
 byte_BANKF_F099:
 	.db $02,$02,$03,$00 ; $00
 	.db $03,$03,$F8,$00 ; $04

--- a/src/ram.asm
+++ b/src/ram.asm
@@ -58,6 +58,7 @@ byte_RAM_10:
 	.dsb 1 ; $0010
 ScreenUpdateIndex:
 	.dsb 1 ; $0011
+; next object slot to use?
 byte_RAM_12:
 	.dsb 1 ; $0012
 BreakStartLevelLoop:
@@ -323,8 +324,8 @@ EnemyArray_B1:
 	.dsb 1 ; $00b8
 	.dsb 1 ; $00b9
 
-; PlayerXCameraOffset?
-byte_RAM_BA:
+; Not exactly velocity. Functions more like "move camera X pixels on the next frame"
+CameraVelocityX:
 	.dsb 1 ; $00ba
 CurrentMusicPointer:
 	.dsb 2 ; $00bb
@@ -390,11 +391,15 @@ byte_RAM_D6:
 byte_RAM_D7:
 	.dsb 1 ; $00d7
 
-; @TODO understand better
-; $01 = scroll up, $02 = scroll down
-; (vertical areas only..?)
-NeedVerticalScroll:
+;
+; %xxxxxADD
+;
+; - A = screen interval scrolling is active (vertical levels)
+; - D = direction ($00 = none, $01 = up/left, $02 = down/right)
+;
+NeedsScroll:
 	.dsb 1 ; $00d8
+; This seems related to scrolling rather than enemies...
 EnemyArray_D9:
 	.dsb 1 ; $00d9
 	.dsb 1 ; 1                ; $00da
@@ -474,6 +479,14 @@ StackArea:
 SpriteDMAArea:
 	.dsb $100   ; $0200 - $02FF
 
+;
+; Arbitrary PPU updates happen using the buffer at RAM $0301 when `ScreenUpdateIndex` is zero.
+; In that case, `UpdatePPUFromBufferNMI` will read whatever is in this buffer and update the PPU.
+; When there is nothing to update, the first byte is `$00`, which will cause it to exit.
+;
+; $0300 is used as an offset when writing to the buffer, which allows multiple updates to write to
+; the buffer without overwriting each other.
+;
 byte_RAM_300:
 	.dsb 1 ; $0300
 PPUBuffer_301:
@@ -1129,6 +1142,7 @@ ExtraLives:
 ; $02: Pointer jar
 InJarType:
 	.dsb 1 ; $04ee
+EndOfLevelDoorPage: ;;;
 unk_RAM_4EF:
 	.dsb 1 ; $04ef
 	.dsb 1 ; $04f0
@@ -1159,6 +1173,7 @@ StopwatchTimer:
 	.dsb 1 ; $0500
 ; FOR RENT
 	.dsb 1 ; $0501
+; Flag enabled while the area is rendering on initialization
 byte_RAM_502:
 	.dsb 1 ; $0502
 ; FOR RENT
@@ -1251,12 +1266,15 @@ CurrentLevelPage:
 	.dsb 1 ; $0535
 CurrentLevelPageX:
 	.dsb 1 ; $0536
+; Flag to break out of the area initilaization loop?
 byte_RAM_537:
 	.dsb 1 ; $0537
-byte_RAM_538:
+; $00 = none, $01 = left, $02 = right
+HorizontalScrollDirection:
 	.dsb 1 ; $0538
 byte_RAM_539:
 	.dsb 1 ; $0539
+; Flag to enable redrawing the background?
 byte_RAM_53A:
 	.dsb 1 ; $053a
 	.dsb 1 ; $053b

--- a/src/ram.asm
+++ b/src/ram.asm
@@ -327,8 +327,9 @@ EnemyArray_B1:
 	.dsb 1 ; $00b8
 	.dsb 1 ; $00b9
 
-; Not exactly velocity. Functions more like "move camera X pixels on the next frame"
-CameraVelocityX:
+; Number of pixels to shift the camera on the next frame to get to its "ideal"
+; position. The left/right bounds of the area will overrule this.
+MoveCameraX:
 	.dsb 1 ; $00ba
 CurrentMusicPointer:
 	.dsb 2 ; $00bb

--- a/src/ram.asm
+++ b/src/ram.asm
@@ -355,11 +355,9 @@ SoundEffectTimer2:
 	.dsb 1 ; $00c6
 PlayerAnimationFrame:
 	.dsb 1 ; $00c7
-; related to y-mirroring
-byte_RAM_C8:
+PPUScrollYHiMirror:
 	.dsb 1 ; $00c8
-; related to x-mirroring
-byte_RAM_C9:
+PPUScrollXHiMirror:
 	.dsb 1 ; $00c9
 ; Not sure about this, but seems to be that way
 ScreenYHi:
@@ -848,8 +846,9 @@ EnemyArray_438:
 
 ; FOR RENT
 	.dsb 1 ; $0440
-; Despawn offset
-unk_RAM_441:
+; Raw enemy data offset used to prevent enemy from spawning multiple times.
+; A value of `$FF` indicates that the enemy is not linked to any particular level data.
+EnemyRawDataOffset:
 	.dsb 1 ; $0441
 	.dsb 1 ; $0442
 	.dsb 1 ; $0443
@@ -1178,9 +1177,9 @@ PPUScrollYMirror_Backup:
 	.dsb 1 ; $0509
 PPUScrollXMirror_Backup:
 	.dsb 1 ; $050a
-byte_RAM_50B:
+PPUScrollYHiMirror_Backup:
 	.dsb 1 ; $050b
-byte_RAM_50C:
+PPUScrollXHiMirror_Backup:
 	.dsb 1 ; $050c
 byte_RAM_50D:
 	.dsb 1 ; $050d

--- a/src/ram.asm
+++ b/src/ram.asm
@@ -2042,23 +2042,10 @@ MMC5_SND_CHN = $5015
 
 DecodedLevelData = $6000
 
-; collision y data?
-; byte_BANKF_F099 copied to RAM
-; these various addrs are used(?) around prg-2-3
-unk_RAM_7100 = $7100
-
-; something to do with hawkmouth
-byte_RAM_710B = $710b
-
-unk_RAM_7114 = $7114
-
-; something to do with hawkmouth
-byte_RAM_711F = $711f
-
-; collision x data?
-unk_RAM_7128 = $7128
-
-unk_RAM_713C = $713c
+ObjectCollisionHitboxLeft_RAM = $7100
+ObjectCollisionHitboxTop_RAM = $7114
+ObjectCollisionHitboxRight_RAM = $7128
+ObjectCollisionHitboxBottom_RAM = $713c
 
 ; MysteryData14439 copied to RAM
 ; Does anything read this???

--- a/src/ram.asm
+++ b/src/ram.asm
@@ -1688,18 +1688,17 @@ MaxLevelsCompleted:
 LevelObjectMode:
 	.dsb 1 ; $0633
 
-IFDEF AREA_HEADER_TILESET
-CurrentWorldTileset:
-	.dsb 1 ; $0634
-CurrentWorld:
-	.dsb 1 ; $0635
-ENDIF
-
 IFNDEF AREA_HEADER_TILESET
 ; FOR RENT
 	.dsb 1 ; $0634
 CurrentWorld:
 CurrentWorldTileset:
+	.dsb 1 ; $0635
+
+ELSE
+CurrentWorldTileset:
+	.dsb 1 ; $0634
+CurrentWorld:
 	.dsb 1 ; $0635
 ENDIF
 


### PR DESCRIPTION
I've had a bunch of these changes sitting around on my fork for a while, so here they are!

## Summary

### Annotation and label naming
* Scrolling routines
* Drawing routines
* Collision detection routines
* Level objects (green platforms and vines)

### Other changes
* Fixed the FME7 header to prevent part of the WRAM from being read-only and causing crashes
* Added `.ignorenl` to `config.asm` to cut down on erroneous labels in the Mesen debugger
