### PR TITLE
Various informative comments, enemy behavior labeling

### DIFF
--- a/config.asm
+++ b/config.asm
@@ -98,6 +98,9 @@ ENDIF
 ; Fixes green platform tiles in Subspace
 ; FIX_SUBSPACE_TILES = 1
 
+; Fixes rare softlock when Fryguy doesn't create all four mini flames
+; FIX_FRYGUY_SPLIT_COUNT = 1
+
 ; Supports D1 joypad data for expansion port controllers
 ; JOYPAD_D1 = 1
 

--- a/src/defs.asm
+++ b/src/defs.asm
@@ -356,6 +356,19 @@ ObjAttrib_UpsideDown = %10000000 ; appears behind background when pulling
 
 ; ---------------------------------------------------------------------------
 
+; enum SpriteFlags46E (bitfield) (width 1 byte)
+SpriteFlags46E_00 = %00000000
+SpriteFlags46E_Damage = %00000001 ; Causes damage when touched from above
+SpriteFlags46E_Unliftable = %00000010
+SpriteFlags46E_NoEnemyCollision = %00000100 ; Disables collision with other enemies
+SpriteFlags46E_DeathSquawk = %00001000 ; Squawk on death (and prevents despawning offscreen)
+SpriteFlags46E_Tilemap2 = %00010000
+SpriteFlags46E_WideSprite = %00100000 ; Only used for Mouser
+SpriteFlags46E_DoubleSpeed = %01000000
+SpriteFlags46E_MirrorAnimation = %10000000
+
+; ---------------------------------------------------------------------------
+
 ; enum BackgroundTileIds
 BackgroundTile_Black = $00
 BackgroundTile_BgCloudLeft = $01
@@ -768,7 +781,6 @@ CollisionFlags_PlayerInsideMaybe = %01000000
 CollisionFlags_80 = %10000000
 
 ; enum CHRBank (width 1 byte)
-
 CHRBank_Mario = $00
 CHRBank_Luigi = $01
 CHRBank_Princess = $02

--- a/src/defs.asm
+++ b/src/defs.asm
@@ -238,9 +238,9 @@ PPUStatus_VBlankHit = %10000000
 ; ---------------------------------------------------------------------------
 
 ; enum SoundEffect3
-SoundEffect3_ShortNoise = $01 ; Whale spout
-SoundEffect3_Rumble_A = $02 ; Rocket
-SoundEffect3_Rumble_B = $04 ; POW rumble
+SoundEffect3_WhaleSpout = $01
+SoundEffect3_Rocket = $02
+SoundEffect3_POWRumble = $04
 
 ; ---------------------------------------------------------------------------
 

--- a/src/prg-2-3.asm
+++ b/src/prg-2-3.asm
@@ -1738,6 +1738,7 @@ loc_BANK2_8891:
 
 ; =============== S U B R O U T I N E =======================================
 
+; Ensures that x-wrapping applies properly to sprites
 sub_BANK2_8894:
 	LDA #$00
 	STA byte_RAM_EE
@@ -2678,9 +2679,9 @@ EnemyInit_Hawkmouth:
 	DEC ObjectYLo, X
 	DEC ObjectYLo, X
 	LDY #$01
-	STY ObjectCollisionHitboxTop_RAM + $0B
+	STY HawkmouthCollisionHitboxTop_RAM
 	INY
-	STY ObjectCollisionHitboxLeft_RAM + $0B
+	STY HawkmouthCollisionHitboxLeft_RAM
 
 
 EnemyInit_Stationary:
@@ -2762,8 +2763,8 @@ loc_BANK2_8DBA:
 	AND #$03
 	BNE loc_BANK2_8DD8
 
-	DEC ObjectCollisionHitboxTop_RAM + $0B
-	INC ObjectCollisionHitboxLeft_RAM + $0B
+	DEC HawkmouthCollisionHitboxTop_RAM
+	INC HawkmouthCollisionHitboxLeft_RAM
 
 loc_BANK2_8DD8:
 	JMP RenderSprite_HawkmouthLeft

--- a/src/prg-2-3.asm
+++ b/src/prg-2-3.asm
@@ -289,7 +289,7 @@ ENDIF
 
 	; Handle the stopwatch
 	LDA byte_RAM_10
-	AND #$1F
+	AND #%00011111
 	BNE AreaMainRoutine_DecrementStopwatch
 
 	LDY #SoundEffect1_StopwatchTick
@@ -3977,7 +3977,7 @@ Phanto_AfterFlashing:
 	STA ObjectShakeTimer, X
 
 	; Play Phanto activation sound effect
-	LDA #SoundEffect3_Rumble_B
+	LDA #SoundEffect3_POWRumble
 	STA SoundEffectQueue3
 
 Phanto_AfterSound:
@@ -4744,7 +4744,7 @@ loc_BANK2_96EC:
 
 	LDA #$20
 	STA POWQuakeTimer
-	LDA #SoundEffect3_Rumble_B
+	LDA #SoundEffect3_POWRumble
 	STA SoundEffectQueue3
 	JMP sub_BANK2_98C4
 
@@ -8676,7 +8676,7 @@ EnemyBehavior_Rocket_Launching:
 	; Setting EnemyArray_B1 puts the rocket in the area
 	STA EnemyArray_B1, X
 	STA PlayerInRocket
-	LDA #SoundEffect3_Rumble_A
+	LDA #SoundEffect3_Rocket
 	STA SoundEffectQueue3
 	LDA #$FE
 	STA ObjectYVelocity, X
@@ -9227,7 +9227,7 @@ loc_BANK3_AEC3:
 	STA ObjectYLo, X
 
 loc_BANK3_AECD:
-	LDA #SoundEffect3_ShortNoise
+	LDA #SoundEffect3_WhaleSpout
 	STA SoundEffectQueue3
 	LDA EnemyVariable, X
 	CMP #$80

--- a/src/prg-2-3.asm
+++ b/src/prg-2-3.asm
@@ -4884,7 +4884,7 @@ loc_BANK2_977F:
 	STY byte_RAM_F4
 
 loc_BANK2_9784:
-	LDA #$7A
+	LDA #$7A ; Door opening
 	JSR RenderSprite_DrawObject
 
 	LDY byte_RAM_F4
@@ -4924,11 +4924,11 @@ loc_BANK2_97AF:
 	STY byte_RAM_F4
 
 loc_BANK2_97BA:
-	LDA #$76
+	LDA #$76 ; Door
 	LDY EnemyArray_477, X
 	BEQ loc_BANK2_97C3
 
-	LDA #$7E
+	LDA #$7E ; Door with lock
 
 loc_BANK2_97C3:
 	JSR RenderSprite_DrawObject
@@ -5403,9 +5403,9 @@ EnemyTilemap1:
 	; Shyguy
 	.db $D0, $D2 ; $00
 	.db $D4, $D6 ; $02
-	; Wart vegetable? (onion)
+	; Wart vegetable (onion)
 	.db $F8, $F8 ; $04
-	; Wart vegetable? (tomato)
+	; Wart vegetable (tomato)
 	.db $FA, $FA ; $06
 	; Tweeter
 	.db $CC, $CE ; $08

--- a/src/prg-2-3.asm
+++ b/src/prg-2-3.asm
@@ -5935,7 +5935,8 @@ loc_BANK2_9C07:
 	ASL A
 	LDA ObjectAnimationTimer, X
 	LDX byte_RAM_F
-	AND #$08
+ObjectAnimationTimerMask:
+	AND #$08 ; determines how often to alternate between animation frames
 	BEQ loc_BANK2_9C31
 
 	BCC loc_BANK2_9C1F

--- a/src/prg-2-3.asm
+++ b/src/prg-2-3.asm
@@ -2922,21 +2922,28 @@ EnemyBehavior_Trouter_Exit:
 
 
 ;
-; Trouter jump height, which is determined by Y-position
+; Trouter jump height, which is determined by initial vertical position
 ;
 TrouterJumpVelocityY:
-	.db $AC
-	.db $AE
-	.db $B1
-	.db $B5
-	.db $B8
-	.db $BC
-	.db $C0
-	.db $C4
-	.db $C8
-	.db $CC
-	.db $D2
-	.db $D8
+	.db $AC ; $0
+	.db $AE ; $1
+	.db $B1 ; $2
+	.db $B5 ; $3
+	.db $B8 ; $4
+	.db $BC ; $5
+	.db $C0 ; $6
+	.db $C4 ; $7
+	.db $C8 ; $8
+	.db $CC ; $9
+	.db $D2 ; $A
+	.db $D8 ; $B
+; They didn't even bother this close to the bottom of the screen!
+IFDEF EXPAND_TABLES
+	.db $DF ; $C
+	.db $E6 ; $D
+	.db $EF ; $E
+	.db $F8 ; $F
+ENDIF
 
 TrouterMaxY:
 	.db $92 ; vertical level

--- a/src/prg-4-5.asm
+++ b/src/prg-4-5.asm
@@ -100,6 +100,12 @@ ProcessSoundEffectQueue2_CoinGetPart2:
 	CMP #$30
 	BNE ProcessSoundEffectQueue2_ThenDecrementTimer
 
+	; The second note of the coin sound effect modifies the frequency directly!
+	; This was probably done to do the "same" thing in similar instructions.
+	;
+	; It's interesting to point out that the closest "regular" note ($68) would
+	; end up with SQ1_LO being $53 instead of $54 from the frequency tweak logic!
+
 	LDA #$54
 	STA SQ1_LO
 
@@ -229,14 +235,15 @@ ProcessSoundEffectQueue2_GrowingPart2:
 	BCS ProcessSoundEffectQueue2_DecrementTimer
 
 	TAY
-	LDA MushroomSoundData - 1, Y
+	LDA GrowingSoundData - 1, Y
 	LDX #$5D
 	LDY #$7F
 	JSR PlaySquare1Sweep
 
 	JMP ProcessSoundEffectQueue2_DecrementTimer
 
-MushroomSoundData:
+; Fun fact: When you slow this down, you get the SMB1 end of level fanfare.
+GrowingSoundData:
 	.db $6A, $74, $6A, $64, $5C, $52, $5C, $52, $4C, $44, $66, $70, $66, $60, $58, $4E
 	.db $58, $4E, $48, $40, $56, $60, $56, $50, $48, $3E, $48, $3E, $38, $30 ; $10
 

--- a/src/prg-4-5.asm
+++ b/src/prg-4-5.asm
@@ -319,11 +319,11 @@ ProcessSoundEffectQueue1_Exit:
 .include "src/music/sound-effect-data.asm"
 
 
-ProcessSoundEffectQueue3_ShortNoise:
+ProcessSoundEffectQueue3_WhaleSpout:
 	LDA #$02
 	STA SoundEffectTimer3
 
-ProcessSoundEffectQueue3_ShortNoisePart2:
+ProcessSoundEffectQueue3_WhaleSpoutPart2:
 	LDA #$1A
 	STA NOISE_VOL
 	LDA #$04
@@ -336,33 +336,43 @@ ProcessSoundEffectQueue3:
 	BEQ ProcessSoundEffectQueue3_Part2
 
 	STY SoundEffectPlaying3
-	LSR SoundEffectQueue3
-	BCS ProcessSoundEffectQueue3_ShortNoise
 
+	; Whale spout
 	LSR SoundEffectQueue3
-	BCS ProcessSoundEffectQueue3_Rumble
+	BCS ProcessSoundEffectQueue3_WhaleSpout
 
+	; Rocket
 	LSR SoundEffectQueue3
-	BCS ProcessSoundEffectQueue3_Rumble
+	BCS ProcessSoundEffectQueue3_Rocket
+
+	; POW rumble
+	LSR SoundEffectQueue3
+	BCS ProcessSoundEffectQueue3_POWRumble
 
 ProcessSoundEffectQueue3_Part2:
 	LDA SoundEffectPlaying3
-	LSR A
-	BCS ProcessSoundEffectQueue3_ShortNoisePart2
 
+	; Whale spout
 	LSR A
-	BCS ProcessSoundEffectQueue3_RumblePart2
+	BCS ProcessSoundEffectQueue3_WhaleSpoutPart2
 
+	; Rocket
 	LSR A
-	BCS ProcessSoundEffectQueue3_RumblePart2
+	BCS ProcessSoundEffectQueue3_RocketPart2
+
+	; POW rumble
+	LSR A
+	BCS ProcessSoundEffectQueue3_POWRumblePart2
 
 	RTS
 
-ProcessSoundEffectQueue3_Rumble:
+ProcessSoundEffectQueue3_Rocket:
+ProcessSoundEffectQueue3_POWRumble:
 	LDA #$7F
 	STA SoundEffectTimer3
 
-ProcessSoundEffectQueue3_RumblePart2:
+ProcessSoundEffectQueue3_RocketPart2:
+ProcessSoundEffectQueue3_POWRumblePart2:
 	LDY SoundEffectTimer3
 	LDA ProcessMusicQueue, Y ; weird, but i guess that's one way to get "random" noise
 	ORA #$0C

--- a/src/prg-a-b.asm
+++ b/src/prg-a-b.asm
@@ -485,6 +485,9 @@ loc_BANKA_84A0:
 	BPL loc_BANKA_84A0
 
 	; Copy object collision hitbox table
+	;
+	; The fact that it's in RAM is taken advantage of to programmatically change
+	; the hitbox for Hawkmouth after picking up the crystal.
 	LDY #$4F
 loc_BANKA_84AB:
 	LDA ObjectCollisionHitboxLeft, Y
@@ -501,6 +504,9 @@ loc_BANKA_84B6:
 	BPL loc_BANKA_84B6
 
 	; Copy object collision type table
+	;
+	; The fact that it's in RAM is used to toggle the Boss Hawkmouth between an
+	; object and an enemy.
 	LDY #$49
 loc_BANKA_84C1:
 	LDA EnemyPlayerCollisionTable, Y

--- a/src/prg-e-f.asm
+++ b/src/prg-e-f.asm
@@ -5613,7 +5613,7 @@ BackgroundCHRAnimationSpeedByWorld:
 	.db $09 ; World 5
 	.db $07 ; World 6
 	.db $05 ; World 7
-	.db $0B ; Default (slow)
+	.db $0B ; Default
 
 
 ;

--- a/src/prg-e-f.asm
+++ b/src/prg-e-f.asm
@@ -874,8 +874,6 @@ ContinueGame:
 	STA ExtraLives
 
 GoToWorldStartingLevel:
-	; LDX #$03 ;;;
-	; STX CurrentWorld ;;;
 	LDX CurrentWorld
 	LDY WorldStartingLevel, X
 	STY CurrentLevel

--- a/src/prg-e-f.asm
+++ b/src/prg-e-f.asm
@@ -5613,7 +5613,7 @@ BackgroundCHRAnimationSpeedByWorld:
 	.db $09 ; World 5
 	.db $07 ; World 6
 	.db $05 ; World 7
-	.db $0B ; Default
+	.db $0B ; Default (slow)
 
 
 ;

--- a/src/prg-e-f.asm
+++ b/src/prg-e-f.asm
@@ -874,6 +874,8 @@ ContinueGame:
 	STA ExtraLives
 
 GoToWorldStartingLevel:
+	; LDX #$03 ;;;
+	; STX CurrentWorld ;;;
 	LDX CurrentWorld
 	LDY WorldStartingLevel, X
 	STY CurrentLevel
@@ -4073,77 +4075,77 @@ ObjectAttributeTable:
 ;   bit 1 ($02) - unliftable
 ;   bit 0 ($01) - hurts when touched from above
 EnemyArray_46E_Data:
-	.db %00000100 ; $00 Enemy_Heart
-	.db %00000000 ; $01 Enemy_ShyguyRed
-	.db %00000000 ; $02 Enemy_Tweeter
-	.db %00000000 ; $03 Enemy_ShyguyPink
-	.db %00000011 ; $04 Enemy_Porcupo
-	.db %00000000 ; $05 Enemy_SnifitRed
-	.db %00000000 ; $06 Enemy_SnifitGray
-	.db %00000000 ; $07 Enemy_SnifitPink
-	.db %01010000 ; $08 Enemy_Ostro
-	.db %01000000 ; $09 Enemy_BobOmb
-	.db %01000010 ; $0A Enemy_AlbatossCarryingBobOmb
-	.db %01000010 ; $0B Enemy_AlbatossStartRight
-	.db %01000010 ; $0C Enemy_AlbatossStartLeft
-	.db %01000000 ; $0D Enemy_NinjiRunning
-	.db %01000000 ; $0E Enemy_NinjiJumping
-	.db %01000000 ; $0F Enemy_BeezoDiving
-	.db %01000000 ; $10 Enemy_BeezoStraight
-	.db %00010011 ; $11 Enemy_WartBubble
-	.db %11010000 ; $12 Enemy_Pidgit
-	.db %10000000 ; $13 Enemy_Trouter
-	.db %00000000 ; $14 Enemy_Hoopstar
-	.db %00000110 ; $15 Enemy_JarGeneratorShyguy
-	.db %00000110 ; $16 Enemy_JarGeneratorBobOmb
-	.db %00000111 ; $17 Enemy_Phanto
-	.db %00010000 ; $18 Enemy_CobratJar
-	.db %01010000 ; $19 Enemy_CobratSand
-	.db %10010000 ; $1A Enemy_Pokey
-	.db %00000111 ; $1B Enemy_Bullet
-	.db %00001010 ; $1C Enemy_Birdo
-	.db %00111011 ; $1D Enemy_Mouser
-	.db %01000000 ; $1E Enemy_Egg
-	.db %00011000 ; $1F Enemy_Tryclyde
-	.db %00000111 ; $20 Enemy_Fireball
-	.db %00011011 ; $21 Enemy_Clawgrip
-	.db %00010000 ; $22 Enemy_ClawgripRock
-	.db %00000111 ; $23 Enemy_PanserStationaryFiresAngled
-	.db %00000111 ; $24 Enemy_PanserWalking
-	.db %00000111 ; $25 Enemy_PanserStationaryFiresUp
-	.db %01010000 ; $26 Enemy_Autobomb
-	.db %01010011 ; $27 Enemy_AutobombFire
-	.db %10010110 ; $28 Enemy_WhaleSpout
-	.db %01010000 ; $29 Enemy_Flurry
-	.db %10011011 ; $2A Enemy_Fryguy
-	.db %11010011 ; $2B Enemy_FryguySplit
-	.db %00011011 ; $2C Enemy_Wart
-	.db %00001011 ; $2D Enemy_HawkmouthBoss
-	.db %00000011 ; $2E Enemy_Spark1
-	.db %00000011 ; $2F Enemy_Spark2
-	.db %00000011 ; $30 Enemy_Spark3
-	.db %00000011 ; $31 Enemy_Spark4
-	.db %00000000 ; $32 Enemy_VegetableSmall
-	.db %00000000 ; $33 Enemy_VegetableLarge
-	.db %00000000 ; $34 Enemy_VegetableWart
-	.db %00000000 ; $35 Enemy_Shell
-	.db %00000100 ; $36 Enemy_Coin
-	.db %00000100 ; $37 Enemy_Bomb
-	.db %00000100 ; $38 Enemy_Rocket
-	.db %00000000 ; $39 Enemy_MushroomBlock
-	.db %00000000 ; $3A Enemy_POWBlock
-	.db %00000110 ; $3B Enemy_FallingLogs
-	.db %00000100 ; $3C Enemy_SubspaceDoor
-	.db %00000000 ; $3D Enemy_Key
-	.db %00000100 ; $3E Enemy_SubspacePotion
-	.db %00000100 ; $3F Enemy_Mushroom
-	.db %00000100 ; $40 Enemy_Mushroom1up
-	.db %00010110 ; $41 Enemy_FlyingCarpet
-	.db %00000110 ; $42 Enemy_HawkmouthRight
-	.db %00000110 ; $43 Enemy_HawkmouthLeft
-	.db %00001100 ; $44 Enemy_CrystalBall
-	.db %00000100 ; $45 Enemy_Starman
-	.db %00000100 ; $46 Enemy_Stopwatch
+	.db SpriteFlags46E_NoEnemyCollision ; $00 Enemy_Heart
+	.db SpriteFlags46E_00 ; $01 Enemy_ShyguyRed
+	.db SpriteFlags46E_00 ; $02 Enemy_Tweeter
+	.db SpriteFlags46E_00 ; $03 Enemy_ShyguyPink
+	.db SpriteFlags46E_Damage | SpriteFlags46E_Unliftable ; $04 Enemy_Porcupo
+	.db SpriteFlags46E_00 ; $05 Enemy_SnifitRed
+	.db SpriteFlags46E_00 ; $06 Enemy_SnifitGray
+	.db SpriteFlags46E_00 ; $07 Enemy_SnifitPink
+	.db SpriteFlags46E_Tilemap2 | SpriteFlags46E_DoubleSpeed ; $08 Enemy_Ostro
+	.db SpriteFlags46E_DoubleSpeed ; $09 Enemy_BobOmb
+	.db SpriteFlags46E_Unliftable | SpriteFlags46E_DoubleSpeed ; $0A Enemy_AlbatossCarryingBobOmb
+	.db SpriteFlags46E_Unliftable | SpriteFlags46E_DoubleSpeed ; $0B Enemy_AlbatossStartRight
+	.db SpriteFlags46E_Unliftable | SpriteFlags46E_DoubleSpeed ; $0C Enemy_AlbatossStartLeft
+	.db SpriteFlags46E_DoubleSpeed ; $0D Enemy_NinjiRunning
+	.db SpriteFlags46E_DoubleSpeed ; $0E Enemy_NinjiJumping
+	.db SpriteFlags46E_DoubleSpeed ; $0F Enemy_BeezoDiving
+	.db SpriteFlags46E_DoubleSpeed ; $10 Enemy_BeezoStraight
+	.db SpriteFlags46E_Damage | SpriteFlags46E_Unliftable | SpriteFlags46E_Tilemap2 ; $11 Enemy_WartBubble
+	.db SpriteFlags46E_Tilemap2 | SpriteFlags46E_DoubleSpeed | SpriteFlags46E_MirrorAnimation ; $12 Enemy_Pidgit
+	.db SpriteFlags46E_MirrorAnimation ; $13 Enemy_Trouter
+	.db SpriteFlags46E_00 ; $14 Enemy_Hoopstar
+	.db SpriteFlags46E_Unliftable | SpriteFlags46E_NoEnemyCollision ; $15 Enemy_JarGeneratorShyguy
+	.db SpriteFlags46E_Unliftable | SpriteFlags46E_NoEnemyCollision ; $16 Enemy_JarGeneratorBobOmb
+	.db SpriteFlags46E_Damage | SpriteFlags46E_Unliftable | SpriteFlags46E_NoEnemyCollision ; $17 Enemy_Phanto
+	.db SpriteFlags46E_Tilemap2 ; $18 Enemy_CobratJar
+	.db SpriteFlags46E_Tilemap2 | SpriteFlags46E_DoubleSpeed ; $19 Enemy_CobratSand
+	.db SpriteFlags46E_Tilemap2 | SpriteFlags46E_MirrorAnimation ; $1A Enemy_Pokey
+	.db SpriteFlags46E_Damage | SpriteFlags46E_Unliftable | SpriteFlags46E_NoEnemyCollision ; $1B Enemy_Bullet
+	.db SpriteFlags46E_Unliftable | SpriteFlags46E_DeathSquawk ; $1C Enemy_Birdo
+	.db SpriteFlags46E_Damage | SpriteFlags46E_Unliftable | SpriteFlags46E_DeathSquawk | SpriteFlags46E_Tilemap2 | SpriteFlags46E_WideSprite ; $1D Enemy_Mouser
+	.db SpriteFlags46E_DoubleSpeed ; $1E Enemy_Egg
+	.db SpriteFlags46E_DeathSquawk | SpriteFlags46E_Tilemap2 ; $1F Enemy_Tryclyde
+	.db SpriteFlags46E_Damage | SpriteFlags46E_Unliftable | SpriteFlags46E_NoEnemyCollision ; $20 Enemy_Fireball
+	.db SpriteFlags46E_Damage | SpriteFlags46E_Unliftable | SpriteFlags46E_DeathSquawk | SpriteFlags46E_Tilemap2 ; $21 Enemy_Clawgrip
+	.db SpriteFlags46E_Tilemap2 ; $22 Enemy_ClawgripRock
+	.db SpriteFlags46E_Damage | SpriteFlags46E_Unliftable | SpriteFlags46E_NoEnemyCollision ; $23 Enemy_PanserStationaryFiresAngled
+	.db SpriteFlags46E_Damage | SpriteFlags46E_Unliftable | SpriteFlags46E_NoEnemyCollision ; $24 Enemy_PanserWalking
+	.db SpriteFlags46E_Damage | SpriteFlags46E_Unliftable | SpriteFlags46E_NoEnemyCollision ; $25 Enemy_PanserStationaryFiresUp
+	.db SpriteFlags46E_Tilemap2 | SpriteFlags46E_DoubleSpeed ; $26 Enemy_Autobomb
+	.db SpriteFlags46E_Damage | SpriteFlags46E_Unliftable | SpriteFlags46E_Tilemap2 | SpriteFlags46E_DoubleSpeed ; $27 Enemy_AutobombFire
+	.db SpriteFlags46E_Unliftable | SpriteFlags46E_NoEnemyCollision | SpriteFlags46E_Tilemap2 | SpriteFlags46E_MirrorAnimation ; $28 Enemy_WhaleSpout
+	.db SpriteFlags46E_Tilemap2 | SpriteFlags46E_DoubleSpeed ; $29 Enemy_Flurry
+	.db SpriteFlags46E_Damage | SpriteFlags46E_Unliftable | SpriteFlags46E_DeathSquawk | SpriteFlags46E_Tilemap2 | SpriteFlags46E_MirrorAnimation ; $2A Enemy_Fryguy
+	.db SpriteFlags46E_Damage | SpriteFlags46E_Unliftable | SpriteFlags46E_Tilemap2 | SpriteFlags46E_DoubleSpeed | SpriteFlags46E_MirrorAnimation ; $2B Enemy_FryguySplit
+	.db SpriteFlags46E_Damage | SpriteFlags46E_Unliftable | SpriteFlags46E_DeathSquawk | SpriteFlags46E_Tilemap2 ; $2C Enemy_Wart
+	.db SpriteFlags46E_Damage | SpriteFlags46E_Unliftable | SpriteFlags46E_DeathSquawk ; $2D Enemy_HawkmouthBoss
+	.db SpriteFlags46E_Damage | SpriteFlags46E_Unliftable ; $2E Enemy_Spark1
+	.db SpriteFlags46E_Damage | SpriteFlags46E_Unliftable ; $2F Enemy_Spark2
+	.db SpriteFlags46E_Damage | SpriteFlags46E_Unliftable ; $30 Enemy_Spark3
+	.db SpriteFlags46E_Damage | SpriteFlags46E_Unliftable ; $31 Enemy_Spark4
+	.db SpriteFlags46E_00 ; $32 Enemy_VegetableSmall
+	.db SpriteFlags46E_00 ; $33 Enemy_VegetableLarge
+	.db SpriteFlags46E_00 ; $34 Enemy_VegetableWart
+	.db SpriteFlags46E_00 ; $35 Enemy_Shell
+	.db SpriteFlags46E_NoEnemyCollision ; $36 Enemy_Coin
+	.db SpriteFlags46E_NoEnemyCollision ; $37 Enemy_Bomb
+	.db SpriteFlags46E_NoEnemyCollision ; $38 Enemy_Rocket
+	.db SpriteFlags46E_00 ; $39 Enemy_MushroomBlock
+	.db SpriteFlags46E_00 ; $3A Enemy_POWBlock
+	.db SpriteFlags46E_Unliftable | SpriteFlags46E_NoEnemyCollision ; $3B Enemy_FallingLogs
+	.db SpriteFlags46E_NoEnemyCollision ; $3C Enemy_SubspaceDoor
+	.db SpriteFlags46E_00 ; $3D Enemy_Key
+	.db SpriteFlags46E_NoEnemyCollision ; $3E Enemy_SubspacePotion
+	.db SpriteFlags46E_NoEnemyCollision ; $3F Enemy_Mushroom
+	.db SpriteFlags46E_NoEnemyCollision ; $40 Enemy_Mushroom1up
+	.db SpriteFlags46E_Unliftable | SpriteFlags46E_NoEnemyCollision | SpriteFlags46E_Tilemap2 ; $41 Enemy_FlyingCarpet
+	.db SpriteFlags46E_Unliftable | SpriteFlags46E_NoEnemyCollision ; $42 Enemy_HawkmouthRight
+	.db SpriteFlags46E_Unliftable | SpriteFlags46E_NoEnemyCollision ; $43 Enemy_HawkmouthLeft
+	.db SpriteFlags46E_NoEnemyCollision | SpriteFlags46E_DeathSquawk ; $44 Enemy_CrystalBall
+	.db SpriteFlags46E_NoEnemyCollision ; $45 Enemy_Starman
+	.db SpriteFlags46E_NoEnemyCollision ; $46 Enemy_Stopwatch
 
 ;
 ; Index for tile collision bounding box table

--- a/src/ram.asm
+++ b/src/ram.asm
@@ -2160,6 +2160,9 @@ ObjectCollisionHitboxTop_RAM = $7114
 ObjectCollisionHitboxWidth_RAM = $7128
 ObjectCollisionHitboxHeight_RAM = $713c
 
+HawkmouthCollisionHitboxLeft_RAM = $710b
+HawkmouthCollisionHitboxTop_RAM = $711f
+
 ; Copied from bank A
 ; Does anything read this???
 MysteryData14439_RAM = $7150


### PR DESCRIPTION
- Some comments around sound effects
- Various descriptive labels, especially for enemy behavior
- Enum for `SpriteFlags46E`
- Fix for another rare Fryguy softlock where the weird way the vanilla game counts mini flames can cause a softlock if fewer than 4 are successfully created due to too many fireballs being onscreen